### PR TITLE
Fix win logic

### DIFF
--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -12,10 +12,11 @@
 
 // TF2 defines
 #define TF_MAXPLAYERS					32
-#define TF_ARENA_WINREASON_CAPTURE		1
-#define TF_ARENA_WINREASON_ELIMINATION	2
 
 // TFGO defines
+#define TFGO_ARENA_WINREASON_BOMB_DETONATED	8
+#define TFGO_ARENA_WINREASON_BOMB_DEFUSED	9
+
 #define TFGO_BOMB_DETONATION_WIN_AWARD	3500
 #define TFGO_BOMB_DEFUSE_WIN_AWARD		3500
 #define TFGO_ELIMINATION_WIN_AWARD		3250
@@ -32,7 +33,6 @@ Handle g_10SecondBombTimer;
 Handle g_bombDetonationTimer;
 Handle g_bombDetonationWarningTimer;
 Handle g_bombBeepingTimer;
-Handle g_forcePlantingTeamWinTimer;
 
 // Other handles
 Handle g_hudSync;
@@ -49,6 +49,7 @@ bool g_isMainRoundActive;
 bool g_isBonusRoundActive;
 bool g_isBombPlanted;
 bool g_isBombDetonated;
+bool g_isBombDefused;
 int g_bombPlantingTeam;
 
 // ConVars
@@ -71,7 +72,7 @@ Handle g_SDKRemoveWearable;
 Handle g_SDKGetEquippedWearable;
 Handle g_SDKGetMaxAmmo;
 
-
+#include "tfgo/include/tfgo.inc"
 #include "tfgo/musickits.sp"
 MusicKit g_currentMusicKit;
 
@@ -149,6 +150,8 @@ public void OnMapStart()
 {
 	DHookGamerules(g_dHookSetWinningTeam, false);
 	
+	ResetGameState();
+	
 	PrecacheSounds();
 	PrecacheModels();
 	PrecacheMusicKits();
@@ -224,23 +227,60 @@ public Action OnEndTouchBuyZone(int entity, int client)
 public MRESReturn Hook_SetWinningTeam(Handle hParams)
 {
 	int team = DHookGetParam(hParams, 1);
-	if (g_isBombPlanted)
+	int winReason = DHookGetParam(hParams, 2);
+	
+	//PrintToServer("Team: %d, Win Reason: %d", team, winReason);
+	//PrintToServer("Is bomb planted: %b", g_isBombPlanted);
+	//PrintToServer("Is bomb detonated: %b", g_isBombDetonated);
+	//PrintToServer("Is bomb defused: %b", g_isBombDefused);
+	
+	
+	// Bomb is detonated but game wants to award elimination win on multi-CP maps, rewrite it to make it look like a capture
+	if (g_isBombDetonated && winReason == view_as<int>(Winreason_Elimination))
+	{
+		DHookSetParam(hParams, 2, view_as<int>(Winreason_PointCaptured));
+		return MRES_ChangedHandled;
+	}
+	
+	// Bomb is defused but game wants to award elimination win on multi-CP maps, rewrite it to make it look like a capture
+	else if (g_isBombDefused && team != g_bombPlantingTeam && winReason == view_as<int>(Winreason_Elimination))
+	{
+		DHookSetParam(hParams, 2, view_as<int>(Winreason_PointCaptured));
+		return MRES_ChangedHandled;
+	}
+	// Sometimes the game is stupid and gives defuse win to the planting team, this should prevent that
+	else if (g_isBombDefused && team == g_bombPlantingTeam)
+	{
 		return MRES_Supercede;
-	else if (g_isBombDetonated && team != g_bombPlantingTeam)
+	}
+	
+	// If this is a capture win from planting the bomb we supercede it, otherwise ignore to grant the defusal win
+	else if (g_isBombPlanted && team == g_bombPlantingTeam && (winReason == view_as<int>(Winreason_PointCaptured) || winReason == view_as<int>(Winreason_AllPointsCaptured)))
+	{
 		return MRES_Supercede;
+	}
+	
+	// Planting team was killed while the bomb was active, do not give elimination win to enemy team
+	else if (g_isBombPlanted && team != g_bombPlantingTeam && winReason == view_as<int>(Winreason_Elimination))
+	{
+		return MRES_Supercede;
+	}
+	
+	// Stalemate
+	else if (team == view_as<int>(TFTeam_Unassigned) && winReason == view_as<int>(Winreason_Stalemate))
+	{
+		TFGOTeam red = TFGOTeam(TFTeam_Red);
+		TFGOTeam blue = TFGOTeam(TFTeam_Blue);
+		red.AddToTeamBalance(red.LoseIncome, "Income for triggering stalemate");
+		blue.AddToTeamBalance(blue.LoseIncome, "Income for triggering stalemate");
+		red.LoseStreak++;
+		blue.LoseStreak++;
+		return MRES_Ignored;
+	}
+	
+	// Everything else that doesn't require superceding e.g. eliminating the enemy team
 	else
 	{
-		// Stalemate
-		if (team == view_as<int>(TFTeam_Unassigned))
-		{
-			TFGOTeam red = TFGOTeam(TFTeam_Red);
-			TFGOTeam blue = TFGOTeam(TFTeam_Blue);
-			red.AddToTeamBalance(red.LoseIncome, "Income for triggering stalemate");
-			blue.AddToTeamBalance(blue.LoseIncome, "Income for triggering stalemate");
-			red.LoseStreak++;
-			blue.LoseStreak++;
-		}
-		
 		return MRES_Ignored;
 	}
 }
@@ -321,12 +361,9 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 	if (g_isBombPlanted)
 	{
 		int victimTeam = GetClientTeam(GetClientOfUserId(event.GetInt("userid")));
+		// End the round if every member of the non-planting team died
 		if (g_bombPlantingTeam != victimTeam && GetAliveTeamCount(victimTeam) - 1 <= 0) // -1 because it doesn't work properly in player_death
-		{
-			// End the round if every member of the non-planting team died
-			// TODO: the planting team still loses even if the bomb does detonate
 			g_isBombPlanted = false;
-		}
 	}
 	
 	if (g_isMainRoundActive || g_isBonusRoundActive)
@@ -422,12 +459,11 @@ public Action Event_Teamplay_Point_Captured(Event event, const char[] name, bool
 	event.GetString("cappers", cappers, MaxClients);
 	int team = event.GetInt("team");
 	
-	if (!g_isBombPlanted)
+	g_isBombPlanted = !g_isBombPlanted;
+	if (g_isBombPlanted)
 		PlantBomb(team, event.GetInt("cp"), cappers);
 	else
 		DefuseBomb(team);
-	
-	g_isBombPlanted = !g_isBombPlanted;
 }
 
 void PlantBomb(int team, int cp, const char[] cappers)
@@ -506,9 +542,6 @@ void PlantBomb(int team, int cp, const char[] cappers)
 		}
 	}
 	
-	// Forcing a win for the planting team is required for multi-CP maps because often they don't trigger a win with only one captured CP
-	g_forcePlantingTeamWinTimer = CreateTimer(TFGO_BOMB_DETONATION_TIME, ForcePlantingTeamWin, team_control_point);
-	
 	// Play Sounds
 	g_currentMusicKit.StopMusicForAll(Music_StartAction);
 	g_currentMusicKit.StopMusicForAll(Music_RoundTenSecCount);
@@ -523,14 +556,6 @@ void PlantBomb(int team, int cp, const char[] cappers)
 	char message[256] = "The bomb has been planted.\n%d seconds to detonation.";
 	Format(message, sizeof(message), message, RoundFloat(TFGO_BOMB_DETONATION_TIME));
 	ShowGameMessage(message, "ico_notify_sixty_seconds");
-}
-
-public Action ForcePlantingTeamWin(Handle timer, int team_control_point)
-{
-	if (g_forcePlantingTeamWinTimer != timer)return Plugin_Stop;
-	
-	TF2_ForceTeamWin(view_as<TFTeam>(g_bombPlantingTeam), TF_ARENA_WINREASON_CAPTURE);
-	return Plugin_Continue;
 }
 
 public Action PlayBombBeep(Handle timer, int bomb)
@@ -566,6 +591,10 @@ public Action DetonateBomb(Handle timer, int bombRef)
 	
 	g_isBombDetonated = true;
 	g_isBombPlanted = false;
+	
+	// Only call this after we set g_isBombPlanted to false or the game softlocks
+	TF2_ForceTeamWin(view_as<TFTeam>(g_bombPlantingTeam), view_as<int>(Winreason_AllPointsCaptured));
+	
 	g_bombBeepingTimer = null; // Or else this timer will try to get m_vecOrigin from a deleted bomb
 	
 	int bomb = EntRefToEntIndex(bombRef);
@@ -582,7 +611,8 @@ void DefuseBomb(int team)
 	g_bombDetonationWarningTimer = null;
 	g_bombDetonationTimer = null;
 	
-	TF2_ForceTeamWin(view_as<TFTeam>(team), TF_ARENA_WINREASON_CAPTURE);
+	g_isBombDefused = true;
+	TF2_ForceTeamWin(view_as<TFTeam>(team), view_as<int>(Winreason_PointCaptured));
 }
 
 public Action Event_Arena_Win_Panel(Event event, const char[] name, bool dontBroadcast)
@@ -602,20 +632,18 @@ public Action Event_Arena_Win_Panel(Event event, const char[] name, bool dontBro
 	
 	// Add round end team awards
 	int winreason = event.GetInt("winreason");
-	switch (winreason)
+	if (winreason == view_as<int>(Winreason_PointCaptured) || winreason == view_as<int>(Winreason_AllPointsCaptured))
 	{
-		case TF_ARENA_WINREASON_CAPTURE:
-		{
-			if (g_bombPlantingTeam == event.GetInt("winning_team"))
-				winningTeam.AddToTeamBalance(TFGO_BOMB_DETONATION_WIN_AWARD, "Team award for detonating bomb");
-			else
-				winningTeam.AddToTeamBalance(TFGO_BOMB_DEFUSE_WIN_AWARD, "Team award for winning by defusing the bomb");
-		}
-		case TF_ARENA_WINREASON_ELIMINATION:
-		{
-			winningTeam.AddToTeamBalance(TFGO_ELIMINATION_WIN_AWARD, "Team award for eliminating the enemy team");
-		}
+		if (g_bombPlantingTeam == event.GetInt("winning_team"))
+			winningTeam.AddToTeamBalance(TFGO_BOMB_DETONATION_WIN_AWARD, "Team award for detonating bomb");
+		else
+			winningTeam.AddToTeamBalance(TFGO_BOMB_DEFUSE_WIN_AWARD, "Team award for winning by defusing the bomb");
 	}
+	else if (winreason == view_as<int>(Winreason_Elimination))
+	{
+		winningTeam.AddToTeamBalance(TFGO_ELIMINATION_WIN_AWARD, "Team award for eliminating the enemy team");
+	}
+	
 	losingTeam.AddToTeamBalance(losingTeam.LoseIncome, "Income for losing");
 	
 	// Adjust team losing streaks
@@ -625,10 +653,19 @@ public Action Event_Arena_Win_Panel(Event event, const char[] name, bool dontBro
 	// Reset timers
 	g_10SecondRoundTimer = null;
 	g_10SecondBombTimer = null;
-	g_forcePlantingTeamWinTimer = null;
+	
+	// Reset game state
+	ResetGameState();
 	
 	// Everyone who survives the post-victory time gets to keep their weapons
 	CreateTimer(mp_bonusroundtime.FloatValue - 0.1, SaveWeaponsForAlivePlayers);
+}
+
+public void ResetGameState()
+{
+	g_isBombPlanted = false;
+	g_isBombDetonated = false;
+	g_isBombDefused = false;
 }
 
 public Action SaveWeaponsForAlivePlayers(Handle timer)

--- a/addons/sourcemod/scripting/tfgo/include/tfgo.inc
+++ b/addons/sourcemod/scripting/tfgo/include/tfgo.inc
@@ -1,0 +1,12 @@
+#if defined _tfgo_included
+	#endinput
+#endif
+#define _tfgo_included
+
+enum Arena_Winreason
+{
+	Winreason_PointCaptured = 1,
+	Winreason_Elimination,
+	Winreason_AllPointsCaptured = 4,
+	Winreason_Stalemate
+}

--- a/addons/sourcemod/scripting/tfgo/stocks.sp
+++ b/addons/sourcemod/scripting/tfgo/stocks.sp
@@ -20,6 +20,7 @@ stock void TF2_ForceTeamWin(TFTeam team, int winReason)
 	char strWinReason[8];
 	IntToString(view_as<int>(team), strWinReason, sizeof(strWinReason));
 	DispatchKeyValue(game_round_win, "win_reason", strWinReason);
+	DispatchKeyValue(game_round_win, "force_map_reset", "1");
 	DispatchSpawn(game_round_win);
 	SetVariantInt(g_bombPlantingTeam);
 	AcceptEntityInput(game_round_win, "SetTeam");


### PR DESCRIPTION
TF:GO currently determines the round winner in a rather primitive way that is very error prone and can even cause the game to softlock on multi-CP maps.

The `SetWinningTeam` function is called every frame after a game is supposed to end and gets two pieces of information - the winning team and the win reason. Combined with saved game state it should be possible to accurately determine the winner and the reason they won to grant the correct money award.

We likely have to program different win logic depending on single-CP or multi-CP. God help me. This will require a shit load of testing and probably a lot of alcohol.


## Arena Win Reasons:

### Capture (1)
Fired when capturing the only control point in the map. At this point the game will try to set the winner to the team that captured the point. If the bomb is currently active, we need to supercede this if the capturing team is the planting team, and let it through if the capturing team is the defusing team.

### Elimination (2)
Fired when all members of a team have been eliminated. We need to supercede this if the bomb has been planted and the planting team dies, as they should still be able to win with all team members being dead.
If the planting team died, this adds the quirk that both win reason 1 (for the planting team) and 2 (for the non-planting team) get fired in an unpredictable order, as the game doesn't know who to give the win to.
Also gets fired and falsely reports a "win by elimination" if the bomb detonates and the last team member gets killed by the blast.

### Unknown (3)
I haven't figured out what this one is yet, but it is pretty safe to say that it can be ignored as I've never seen it get fired.

### Capture Multi (4)
Fired on multi-CP maps when all **required** points have been captured. We can not just ignore this one because it is different for every map, e.g. `arena_byre` only fires this after both points have been captured, whereas `arena_nuke` fires it when you capture a single point. Also, this only gets fired once right after the capture, and then the game gives up.

### Stalemate (5)
Fired when the time runs out in arena. We should always let this one through and grant a stalemate income to both teams.