### PR TITLE
Dynamic Buy Zone

### DIFF
--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -54,6 +54,7 @@ int g_bombPlantingTeam;
 
 // ConVars
 ConVar tfgo_buytime;
+ConVar tfgo_buyzone_radius;
 
 ConVar tf_arena_first_blood;
 ConVar tf_arena_round_time;
@@ -130,6 +131,7 @@ public void OnPluginStart()
 	tf_weapon_criticals_melee = FindConVar("tf_weapon_criticals_melee");
 	mp_bonusroundtime = FindConVar("mp_bonusroundtime");
 	tfgo_buytime = CreateConVar("tfgo_buytime", "45", "How many seconds after spawning players can buy items for", _, true, tf_arena_preround_time.FloatValue);
+	tfgo_buyzone_radius = CreateConVar("tfgo_buyzone_radius", "500", "If the map has no defined buy zone, how far away from their spawn point players can buy items for (in hammer units)");
 	
 	Toggle_ConVars(true);
 	

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -305,7 +305,6 @@ public Action Event_Player_Spawn(Event event, const char[] name, bool dontBroadc
 
 public Action Event_Player_Team(Event event, const char[] name, bool dontBroadcast)
 {
-	// Reset player data on team switch
 	TFGOPlayer player = TFGOPlayer(GetClientOfUserId(event.GetInt("userid")));
 	
 	// Cap balance at highest of the team
@@ -313,10 +312,6 @@ public Action Event_Player_Team(Event event, const char[] name, bool dontBroadca
 	if (player.Balance > highestBalance)
 		player.Balance = highestBalance;
 	player.ClearLoadout();
-	
-	// Cancel buy menu if client switched to spectator  (#4)
-	if (view_as<TFTeam>(event.GetInt("team")) == TFTeam_Spectator && player.ActiveBuyMenu != null)
-		player.ActiveBuyMenu.Cancel();
 }
 
 public Action Event_Player_Death(Event event, const char[] name, bool dontBroadcast)

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -163,7 +163,9 @@ public void OnMapStart()
 	int func_respawnroom = FindEntityByClassname(-1, "func_respawnroom");
 	if (func_respawnroom <= -1)
 	{
-		LogMessage("This map is missing a func_respawnroom entity, calculating dynamic buy zones for each team");
+		g_mapHasRespawnRoom = false;
+		
+		LogMessage("This map is missing a func_respawnroom entity, calculating buy zones based on info_player_teamspawn entities");
 		CalculateDynamicBuyZones();
 	}
 	else

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -215,7 +215,10 @@ public void Hook_OnClientThink(int client)
 		else // Player has left buy zone
 		{
 			if (player.ActiveBuyMenu != null)
+			{
 				player.ActiveBuyMenu.Cancel();
+				PrintHintText(client, "You have left the buy zone");
+			}
 		}
 	}
 }
@@ -251,10 +254,10 @@ public Action OnEndTouchBuyZone(int entity, int client)
 	{
 		TFGOPlayer player = TFGOPlayer(client);
 		if (player.ActiveBuyMenu != null)
+		{
 			player.ActiveBuyMenu.Cancel();
-		
-		if (g_isBuyTimeActive)
 			PrintHintText(client, "You have left the buy zone");
+		}
 	}
 }
 

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -401,9 +401,14 @@ public Action Event_Post_Inventory_Application(Event event, const char[] name, b
 		TFGOPlayer player = TFGOPlayer(client);
 		player.ShowMoneyHudDisplay(tfgo_buytime.FloatValue);
 		player.ApplyLoadout();
+		
 		// Cancel active buy menu or OnGameFrame will throw a million errors
 		if (player.ActiveBuyMenu != null)
 			player.ActiveBuyMenu.Cancel();
+		
+		// func_respawnroom OnStartTouch doesn't fire thus buy menu doesn't get re-opened so we do it manually
+		if (g_mapHasRespawnRoom)
+			ShowMainBuyMenu(client);
 	}
 	
 	return Plugin_Handled;

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -41,7 +41,6 @@ ArrayList g_availableWeapons;
 
 // Map
 bool g_mapHasRespawnRoom;
-float g_avgPlayerStartOrigin[view_as<int>(TFTeam_Blue) + 1][3];
 
 // Game state
 bool g_isGameWaitingForPlayers;
@@ -83,7 +82,7 @@ MusicKit g_currentMusicKit;
 #include "tfgo/methodmaps.sp"
 #include "tfgo/sound.sp"
 #include "tfgo/buymenu.sp"
-
+#include "tfgo/buyzone.sp"
 
 public Plugin myinfo =  {
 	name = "Team Fortress: Global Offensive Arena", 
@@ -165,42 +164,7 @@ public void OnMapStart()
 	if (func_respawnroom <= -1)
 	{
 		LogMessage("This map is missing a func_respawnroom entity, calculating dynamic buy zones for each team");
-		
-		// Calculate average position of each info_player_start for each team
-		for (int team = view_as<int>(TFTeam_Red); team <= view_as<int>(TFTeam_Blue); team++)
-		{
-			ArrayList teamspawns = new ArrayList(3);
-			
-			// Collect info_player_teamspawns for team
-			int info_player_teamspawn;
-			while ((info_player_teamspawn = FindEntityByClassname(info_player_teamspawn, "info_player_teamspawn")) > -1)
-			{
-				int initialTeamNum = GetEntProp(info_player_teamspawn, Prop_Data, "m_iInitialTeamNum");
-				if (team == initialTeamNum)
-				{
-					float origin[3];
-					GetEntPropVector(info_player_teamspawn, Prop_Send, "m_vecOrigin", origin);
-					int length = teamspawns.Length;
-					teamspawns.Resize(length + 1);
-					teamspawns.SetArray(length, origin);
-				}
-			}
-			
-			// Go through each collected info_player_teamspawn for this team and calculate average
-			for (int i = 0; i < teamspawns.Length; i++)
-			{
-				float origin[3];
-				teamspawns.GetArray(i, origin, sizeof(origin));
-				
-				for (int j = 0; j < sizeof(origin); j++)
-				{
-					g_avgPlayerStartOrigin[team][j] += origin[j] / teamspawns.Length;
-				}
-			}
-			
-			LogMessage("Dynamic buy zone for team %d calculated at origin [%f, %f, %f]", team, g_avgPlayerStartOrigin[team][0], g_avgPlayerStartOrigin[team][1], g_avgPlayerStartOrigin[team][2]);
-			delete teamspawns;
-		}
+		CalculateDynamicBuyZones();
 	}
 	else
 	{
@@ -233,36 +197,6 @@ public void OnClientDisconnect(int client)
 	}
 }
 
-public void Hook_OnClientThink(int client)
-{
-	if (g_isBuyTimeActive && IsPlayerAlive(client))
-	{
-		TFGOPlayer player = TFGOPlayer(client);
-		int team = GetClientTeam(client);
-		
-		float origin[3];
-		GetClientAbsOrigin(client, origin);
-		
-		// Calculate total absolute difference between average spawn point and player's current position
-		float difference;
-		for (int i = 0; i < sizeof(origin); i++)difference += FloatAbs(g_avgPlayerStartOrigin[team][i] - origin[i]);
-		
-		if (difference <= tfgo_buyzone_radius.FloatValue) // Player is in buy zone
-		{
-			if (player.ActiveBuyMenu == null)
-				ShowMainBuyMenu(client);
-		}
-		else // Player has left buy zone
-		{
-			if (player.ActiveBuyMenu != null)
-			{
-				player.ActiveBuyMenu.Cancel();
-				PrintHintText(client, "You have left the buy zone");
-			}
-		}
-	}
-}
-
 public void ChooseRandomMusicKit()
 {
 	StringMapSnapshot snapshot = g_availableMusicKits.Snapshot();
@@ -277,27 +211,8 @@ public void OnEntityCreated(int entity, const char[] classname)
 {
 	if (StrEqual(classname, "func_respawnroom"))
 	{
-		SDKHook(entity, SDKHook_StartTouch, OnStartTouchBuyZone);
-		SDKHook(entity, SDKHook_EndTouch, OnEndTouchBuyZone);
-	}
-}
-
-public Action OnStartTouchBuyZone(int entity, int client)
-{
-	if (client >= 1 && client <= MaxClients && IsClientInGame(client) && GetEntProp(entity, Prop_Data, "m_iTeamNum") == GetClientTeam(client))
-		ShowMainBuyMenu(client);
-}
-
-public Action OnEndTouchBuyZone(int entity, int client)
-{
-	if (client >= 1 && client <= MaxClients && IsClientInGame(client) && GetEntProp(entity, Prop_Data, "m_iTeamNum") == GetClientTeam(client))
-	{
-		TFGOPlayer player = TFGOPlayer(client);
-		if (player.ActiveBuyMenu != null)
-		{
-			player.ActiveBuyMenu.Cancel();
-			PrintHintText(client, "You have left the buy zone");
-		}
+		SDKHook(entity, SDKHook_StartTouch, Hook_OnStartTouchBuyZone);
+		SDKHook(entity, SDKHook_EndTouch, Hook_OnEndTouchBuyZone);
 	}
 }
 

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -174,10 +174,6 @@ public void OnMapStart()
 
 public void OnClientConnected(int client)
 {
-	// Hook dynamic buy zone if map has no func_respawnroom
-	if (!g_mapHasRespawnRoom)
-		SDKHook(client, SDKHook_Think, Hook_OnClientThink);
-	
 	// Initialize new player with default values
 	TFGOPlayer player = TFGOPlayer(client);
 	player.ResetBalance();
@@ -189,8 +185,6 @@ public void OnClientConnected(int client)
 
 public void OnClientDisconnect(int client)
 {
-	SDKUnhook(client, SDKHook_Think, Hook_OnClientThink);
-	
 	if (g_isBombPlanted)
 	{
 		// TODO team alive check to  end the round during bomb plant
@@ -296,6 +290,10 @@ public Action Event_Player_Spawn(Event event, const char[] name, bool dontBroadc
 		TF2_RespawnPlayer(client);
 		PrintToChat(client, "This class is currently disabled. Your class has been forcibly changed.");
 	}
+	
+	// Hook dynamic buy zone if map has no func_respawnroom
+	if (!g_mapHasRespawnRoom)
+		SDKHook(client, SDKHook_Think, Hook_OnClientThink);
 }
 
 public Action Event_Player_Team(Event event, const char[] name, bool dontBroadcast)
@@ -386,6 +384,8 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 	
 	if (g_isMainRoundActive || g_isBonusRoundActive)
 		victim.ClearLoadout();
+	
+	SDKUnhook(victim.Client, SDKHook_Think, Hook_OnClientThink);
 	if (victim.ActiveBuyMenu != null)
 		victim.ActiveBuyMenu.Cancel();
 	
@@ -445,6 +445,7 @@ public Action OnBuyTimeExpire(Handle timer)
 		if (IsClientInGame(client))
 		{
 			TFGOPlayer player = TFGOPlayer(client);
+			SDKUnhook(client, SDKHook_Think, Hook_OnClientThink);
 			if (player.ActiveBuyMenu != null)
 				player.ActiveBuyMenu.Cancel();
 		}

--- a/addons/sourcemod/scripting/tfgo/buymenu.sp
+++ b/addons/sourcemod/scripting/tfgo/buymenu.sp
@@ -2,8 +2,6 @@
 // TODO: Proper use of translation files
 public void ShowMainBuyMenu(int client)
 {
-	if (!g_isBuyTimeActive)return;
-	
 	Menu menu = new Menu(HandleBuyMenuFront, MENU_ACTIONS_ALL);
 	menu.SetTitle("%T", "#buymenu_title", LANG_SERVER, TFGOPlayer(client).Balance);
 	

--- a/addons/sourcemod/scripting/tfgo/buymenu.sp
+++ b/addons/sourcemod/scripting/tfgo/buymenu.sp
@@ -42,8 +42,6 @@ public int HandleBuyMenuFront(Menu menu, MenuAction action, int param1, int para
 
 public void ShowBuyMenu(int client, int slot)
 {
-	if (!g_isBuyTimeActive)return;
-	
 	Menu menu = new Menu(HandleBuyMenu, MENU_ACTIONS_ALL);
 	menu.SetTitle("%T", "#buymenu_title", LANG_SERVER, TFGOPlayer(client).Balance);
 	

--- a/addons/sourcemod/scripting/tfgo/buymenu.sp
+++ b/addons/sourcemod/scripting/tfgo/buymenu.sp
@@ -17,7 +17,7 @@ public void ShowMainBuyMenu(int client)
 		}
 	}
 	
-	if (g_mapHasRespawnRoom)menu.ExitButton = false;
+	menu.ExitButton = false;
 	menu.Display(client, MENU_TIME_FOREVER);
 }
 

--- a/addons/sourcemod/scripting/tfgo/buyzone.sp
+++ b/addons/sourcemod/scripting/tfgo/buyzone.sp
@@ -41,13 +41,13 @@ public void CalculateDynamicBuyZones()
 
 public Action Hook_OnStartTouchBuyZone(int entity, int client)
 {
-	if (client >= 1 && client <= MaxClients && IsClientInGame(client) && GetEntProp(entity, Prop_Data, "m_iTeamNum") == GetClientTeam(client))
+	if (g_isBuyTimeActive && client >= 1 && client <= MaxClients && IsClientInGame(client) && GetEntProp(entity, Prop_Data, "m_iTeamNum") == GetClientTeam(client))
 		ShowMainBuyMenu(client);
 }
 
 public Action Hook_OnEndTouchBuyZone(int entity, int client)
 {
-	if (client >= 1 && client <= MaxClients && IsClientInGame(client) && GetEntProp(entity, Prop_Data, "m_iTeamNum") == GetClientTeam(client))
+	if (g_isBuyTimeActive&&client >= 1 && client <= MaxClients && IsClientInGame(client) && GetEntProp(entity, Prop_Data, "m_iTeamNum") == GetClientTeam(client))
 	{
 		TFGOPlayer player = TFGOPlayer(client);
 		if (player.ActiveBuyMenu != null)
@@ -58,9 +58,9 @@ public Action Hook_OnEndTouchBuyZone(int entity, int client)
 	}
 }
 
-public void Hook_OnClientThink(int client)
+public void DisplayMenuInDynamicBuyZone(int client)
 {
-	if (g_isBuyTimeActive && IsPlayerAlive(client))
+	if (IsClientInGame(client) && IsPlayerAlive(client))
 	{
 		TFGOPlayer player = TFGOPlayer(client);
 		int team = GetClientTeam(client);

--- a/addons/sourcemod/scripting/tfgo/buyzone.sp
+++ b/addons/sourcemod/scripting/tfgo/buyzone.sp
@@ -2,6 +2,11 @@ float g_avgPlayerStartOrigin[view_as<int>(TFTeam_Blue) + 1][3];
 
 public void CalculateDynamicBuyZones()
 {
+	// Reset buy zones from previous map
+	for (int i = 0; i < sizeof(g_avgPlayerStartOrigin); i++)
+		for (int j = 0; j < sizeof(g_avgPlayerStartOrigin[]); j++)
+			g_avgPlayerStartOrigin[i][j] = 0.0;
+	
 	// Calculate average position of each info_player_start for each team
 	for (int team = view_as<int>(TFTeam_Red); team <= view_as<int>(TFTeam_Blue); team++)
 	{

--- a/addons/sourcemod/scripting/tfgo/buyzone.sp
+++ b/addons/sourcemod/scripting/tfgo/buyzone.sp
@@ -1,0 +1,89 @@
+float g_avgPlayerStartOrigin[view_as<int>(TFTeam_Blue) + 1][3];
+
+public void CalculateDynamicBuyZones()
+{
+	// Calculate average position of each info_player_start for each team
+	for (int team = view_as<int>(TFTeam_Red); team <= view_as<int>(TFTeam_Blue); team++)
+	{
+		ArrayList teamspawns = new ArrayList(3);
+		
+		// Collect info_player_teamspawns for team
+		int info_player_teamspawn;
+		while ((info_player_teamspawn = FindEntityByClassname(info_player_teamspawn, "info_player_teamspawn")) > -1)
+		{
+			int initialTeamNum = GetEntProp(info_player_teamspawn, Prop_Data, "m_iInitialTeamNum");
+			if (team == initialTeamNum)
+			{
+				float origin[3];
+				GetEntPropVector(info_player_teamspawn, Prop_Send, "m_vecOrigin", origin);
+				int length = teamspawns.Length;
+				teamspawns.Resize(length + 1);
+				teamspawns.SetArray(length, origin);
+			}
+		}
+		
+		// Go through each collected info_player_teamspawn for this team and calculate average
+		for (int i = 0; i < teamspawns.Length; i++)
+		{
+			float origin[3];
+			teamspawns.GetArray(i, origin, sizeof(origin));
+			
+			for (int j = 0; j < sizeof(origin); j++)
+			{
+				g_avgPlayerStartOrigin[team][j] += origin[j] / teamspawns.Length;
+			}
+		}
+		
+		LogMessage("Dynamic buy zone for team %d calculated at origin [%f, %f, %f]", team, g_avgPlayerStartOrigin[team][0], g_avgPlayerStartOrigin[team][1], g_avgPlayerStartOrigin[team][2]);
+		delete teamspawns;
+	}
+}
+
+public Action Hook_OnStartTouchBuyZone(int entity, int client)
+{
+	if (client >= 1 && client <= MaxClients && IsClientInGame(client) && GetEntProp(entity, Prop_Data, "m_iTeamNum") == GetClientTeam(client))
+		ShowMainBuyMenu(client);
+}
+
+public Action Hook_OnEndTouchBuyZone(int entity, int client)
+{
+	if (client >= 1 && client <= MaxClients && IsClientInGame(client) && GetEntProp(entity, Prop_Data, "m_iTeamNum") == GetClientTeam(client))
+	{
+		TFGOPlayer player = TFGOPlayer(client);
+		if (player.ActiveBuyMenu != null)
+		{
+			player.ActiveBuyMenu.Cancel();
+			PrintHintText(client, "You have left the buy zone");
+		}
+	}
+}
+
+public void Hook_OnClientThink(int client)
+{
+	if (g_isBuyTimeActive && IsPlayerAlive(client))
+	{
+		TFGOPlayer player = TFGOPlayer(client);
+		int team = GetClientTeam(client);
+		
+		float origin[3];
+		GetClientAbsOrigin(client, origin);
+		
+		// Calculate total absolute difference between average spawn point and player's current position
+		float difference;
+		for (int i = 0; i < sizeof(origin); i++)difference += FloatAbs(g_avgPlayerStartOrigin[team][i] - origin[i]);
+		
+		if (difference <= tfgo_buyzone_radius.FloatValue) // Player is in buy zone
+		{
+			if (player.ActiveBuyMenu == null)
+				ShowMainBuyMenu(client);
+		}
+		else // Player has left buy zone
+		{
+			if (player.ActiveBuyMenu != null)
+			{
+				player.ActiveBuyMenu.Cancel();
+				PrintHintText(client, "You have left the buy zone");
+			}
+		}
+	}
+}

--- a/addons/sourcemod/scripting/tfgo/buyzone.sp
+++ b/addons/sourcemod/scripting/tfgo/buyzone.sp
@@ -34,7 +34,6 @@ public void CalculateDynamicBuyZones()
 			}
 		}
 		
-		LogMessage("Dynamic buy zone for team %d calculated at origin [%f, %f, %f]", team, g_avgPlayerStartOrigin[team][0], g_avgPlayerStartOrigin[team][1], g_avgPlayerStartOrigin[team][2]);
 		delete teamspawns;
 	}
 }
@@ -47,7 +46,7 @@ public Action Hook_OnStartTouchBuyZone(int entity, int client)
 
 public Action Hook_OnEndTouchBuyZone(int entity, int client)
 {
-	if (g_isBuyTimeActive&&client >= 1 && client <= MaxClients && IsClientInGame(client) && GetEntProp(entity, Prop_Data, "m_iTeamNum") == GetClientTeam(client))
+	if (g_isBuyTimeActive && client >= 1 && client <= MaxClients && IsClientInGame(client) && GetEntProp(entity, Prop_Data, "m_iTeamNum") == GetClientTeam(client))
 	{
 		TFGOPlayer player = TFGOPlayer(client);
 		if (player.ActiveBuyMenu != null)

--- a/addons/sourcemod/scripting/tfgo/methodmaps.sp
+++ b/addons/sourcemod/scripting/tfgo/methodmaps.sp
@@ -20,7 +20,6 @@ int g_defaultWeaponIndexes[][] =  {
 };
 int g_playerLoadoutWeaponIndexes[TF_MAXPLAYERS + 1][view_as<int>(TFClass_Engineer) + 1][view_as<int>(TFWeaponSlot_PDA) + 1];
 int g_playerBalances[TF_MAXPLAYERS + 1] =  { TFGO_STARTING_BALANCE, ... };
-float g_playerSpawnPoints[TF_MAXPLAYERS + 1][3];
 Menu g_activeBuyMenus[TF_MAXPLAYERS + 1];
 
 int g_teamLosingStreaks[view_as<int>(TFTeam_Blue) + 1] =  { TFGO_STARTING_LOSESTREAK, ... };
@@ -77,18 +76,6 @@ methodmap TFGOPlayer
 		{
 			g_activeBuyMenus[this] = val;
 		}
-	}
-	
-	public void GetSpawnPoint(float[3] vec)
-	{
-		for (int i = 0; i < sizeof(vec); i++)
-		vec[i] = g_playerSpawnPoints[this.Client][i];
-	}
-	
-	public void SetSpawnPoint(const float[3] vec)
-	{
-		for (int i = 0; i < sizeof(vec); i++)
-		g_playerSpawnPoints[this.Client] = vec;
 	}
 	
 	public void ShowMoneyHudDisplay(float time)

--- a/addons/sourcemod/scripting/tfgo/methodmaps.sp
+++ b/addons/sourcemod/scripting/tfgo/methodmaps.sp
@@ -20,6 +20,7 @@ int g_defaultWeaponIndexes[][] =  {
 };
 int g_playerLoadoutWeaponIndexes[TF_MAXPLAYERS + 1][view_as<int>(TFClass_Engineer) + 1][view_as<int>(TFWeaponSlot_PDA) + 1];
 int g_playerBalances[TF_MAXPLAYERS + 1] =  { TFGO_STARTING_BALANCE, ... };
+float g_playerSpawnPoints[TF_MAXPLAYERS + 1][3];
 Menu g_activeBuyMenus[TF_MAXPLAYERS + 1];
 
 int g_teamLosingStreaks[view_as<int>(TFTeam_Blue) + 1] =  { TFGO_STARTING_LOSESTREAK, ... };
@@ -76,6 +77,18 @@ methodmap TFGOPlayer
 		{
 			g_activeBuyMenus[this] = val;
 		}
+	}
+	
+	public void GetSpawnPoint(float[3] vec)
+	{
+		for (int i = 0; i < sizeof(vec); i++)
+		vec[i] = g_playerSpawnPoints[this.Client][i];
+	}
+	
+	public void SetSpawnPoint(const float[3] vec)
+	{
+		for (int i = 0; i < sizeof(vec); i++)
+		g_playerSpawnPoints[this.Client] = vec;
 	}
 	
 	public void ShowMoneyHudDisplay(float time)


### PR DESCRIPTION
A lot of arena maps have no `func_respawnroom`, which the gamemode requires to define a buy zone.
Currently, we simply give the player a buy menu on spawn with no way to re-open it after they've manually closed it.

This PR allows the gamemode to define a buy zone for each player based on their spawn point. Its radius can be configured using the `tfgo_buyzone_radius` convar to allow for map-specific configuration.
Dynamic buy zones will only take effect if the map is missing a  `func_respawnroom` entity.