### PR TITLE
Weapon Variants

### DIFF
--- a/addons/sourcemod/configs/tfgo/tfgo.cfg
+++ b/addons/sourcemod/configs/tfgo/tfgo.cfg
@@ -7,10 +7,12 @@
 		"13" // Scattergun
 		{
 			"cost" "3250"
+			"variants" "200;669;799;808;888;897;906;915;964;973;15002;15015;15021;15029;15036;15053;15065;15069;15106;15107;15108;15131;15151;15157"
 		}
 		"45" // Force-A-Nature
 		{
 			"cost" "3100"
+			"variants" "1078"
 		}
 		"220" // Shortstop
 		{
@@ -30,9 +32,14 @@
 		}
 		
 		// Scout - Secondary
+		"23" // Scout's Pistol
+		{
+			"variants" "209;160;294;15013;15018;15035;15041;15046;15056;15060;15061;15100;15101;15102;15126;15148;30666"
+		}
 		"46" // Bonk! Atomic Punch
 		{
 			"cost" "800"
+			"variants" "1145"
 		}
 		"163" // Crit-a-Cola
 		{
@@ -41,6 +48,7 @@
 		"222" // Mad Milk
 		{
 			"cost" "1000"
+			"variants" "1121"
 		}
 		"449" // Winger
 		{
@@ -53,12 +61,21 @@
 		"812" // The Flying Guillotine 
 		{
 			"cost" "600"
+			"variants" "833"
 		}
 		
 		// Scout - Melee
+		"0" // Bat (idiotic defindex)
+		{
+			"variants" "190;660;30667"
+		}
 		"44" // Sandman
 		{
 			"cost" "900"
+		}
+		"221" // Holy Mackerel 
+		{
+			"variants" "572;999"
 		}
 		"317" // Candy Cane
 		{
@@ -67,6 +84,7 @@
 		"325" // Boston Basher
 		{
 			"cost" "600"
+			"variants" "452"
 		}
 		"349" // Sun-on-a-Stick
 		{
@@ -89,6 +107,7 @@
 		"18" // Rocket Launcher
 		{
 			"cost" "4750"
+			"variants" "205;513;658;800;809;889;898;907;916;965;974;15006;15014;15028;15043;15052;15057;15081;15104;15105;15129;15130;15150"
 		}
 		"127" // Direct Hit
 		{
@@ -97,6 +116,7 @@
 		"228" // Black Box
 		{
 			"cost" "4700"
+			"variants" "1085"
 		}
 		"237" // Rocket Jumper
 		{
@@ -120,9 +140,14 @@
 		}
 		
 		// Soldier - Secondary
+		"10" // Soldier's Shotgun
+		{
+			"variants" "199;1141;15003;15016;15044;15047;15085;15109;15132;15133;15152"
+		}
 		"129" // Buff Banner
 		{
 			"cost" "800"
+			"variants" "1001"
 		}
 		"226" // Battalion's Backup
 		{
@@ -146,6 +171,10 @@
 		}
 		
 		// Soldier - Melee
+		"6" // Shovel
+		{
+			"variants" "196"
+		}
 		"128" // Equalizer
 		{
 			"cost" "900"
@@ -164,13 +193,15 @@
 		}
 		
 		// Pyro - Primary
-		"21" // Flame thrower
+		"21" // Flame Thrower
 		{
 			"cost" "4350"
+			"variants" "208;659;741;798;807;887;896;905;914;963;972;15005;15017;15030;15034;15049;15054;1506;15067;15068;15089;15090;15115;15141;30474"
 		}
 		"40" // Backburner
 		{
 			"cost" "4150"
+			"variants" "1146"
 		}
 		"215" // Degreaser
 		{
@@ -186,9 +217,14 @@
 		}
 		
 		// Pyro - Secondary
+		"12" // Pyro's Shotgun
+		{
+			"variants" "199;1141;15003;15016;15044;15047;15085;15109;15132;15133;15152"
+		}
 		"39" // Flare Gun
 		{
 			"cost" "1150"
+			"variants" "1081"
 		}
 		"351" // Detonator
 		{
@@ -212,13 +248,19 @@
 		}
 		
 		// Pyro - Melee
+		"2" // Fire Axe
+		{
+			"variants" "192;739"
+		}
 		"38" // Axtinguisher
 		{
 			"cost" "800"
+			"variants" "457;1000"
 		}
 		"153" // Homewrecker
 		{
 			"cost" "600"
+			"variants" "466"
 		}
 		"214" // Powerjack
 		{
@@ -239,6 +281,7 @@
 		"813" // Neon Annihilator 
 		{
 			"cost" "600"
+			"variants" "834"
 		}
 		"1181" //  Hot Hand
 		{
@@ -249,6 +292,7 @@
 		"19" // Grenade Launcher
 		{
 			"cost" "2350"
+			"variants" "206;1007;15077;15079;15091;15092;15116;15117;15142;15158"
 		}
 		"308" // Loch-n-Load
 		{
@@ -265,16 +309,22 @@
 		"608" // Bootlegger
 		{
 			"cost" "600"
+			"variants" "405"
 		}
 		
 		// Demoman - Secondary
 		"20" // Stickybomb Launcher
 		{
 			"cost" "4250"
+			"variants" "207;661;797;806;886;895;904;913;962;971;15009;15012;15024;15038;15045;15048;15082;15083;15084;15113;15137;15138;15155"
 		}
 		"130" // Scottish Resistance 
 		{
 			"cost" "4200"
+		}
+		"131" // Chargin' Targe
+		{
+			"variants" "1144"
 		}
 		"1150" // Quickiebomb Launcher 
 		{
@@ -294,9 +344,14 @@
 		}
 		
 		// Demoman - Melee
+		"1" // Bottle
+		{
+			"variants" "191;609"
+		}
 		"132" // Eyelander
 		{
 			"cost" "1000"
+			"variants" "266;482"
 		}
 		"172" // Scotsman's Skullcutter 
 		{
@@ -319,6 +374,7 @@
 		"15" // Minigun
 		{
 			"cost" "4650"
+			"variants" "202;298;654;793;802;882;891;900;909;958;967;15004;15020;15026;15031;15040;15055;15086;15087;15088;15098;15099;15123;15124;15125;15147"
 		}
 		"41" // Natascha
 		{
@@ -335,16 +391,23 @@
 		"811" // Huo-Long Heater
 		{
 			"cost" "4050"
+			"variants" "832"
 		}
 		
 		// Heavy - Secondary
+		"11" // Heavy's Shotgun
+		{
+			"variants" "199;1141;15003;15016;15044;15047;15085;15109;15132;15133;15152"
+		}
 		"42" // Sandvich
 		{
 			"cost" "950"
+			"variants" "863;1002"
 		}
 		"159" // Dalokohs Bar
 		{
 			"cost" "700"
+			"variants" "433"
 		}
 		"311" // Buffalo Steak Sandvich
 		{
@@ -360,6 +423,10 @@
 		}
 		
 		// Heavy - Melee
+		"5" // Fists
+		{
+			"variants" "195;587"
+		}
 		"43" // Killing Gloves of Boxing 
 		{
 			"cost" "650"
@@ -367,6 +434,7 @@
 		"239" // Gloves of Running Urgently 
 		{
 			"cost" "800"
+			"variants" "1084;1100"
 		}
 		"310" // Warrior's Spirit 
 		{
@@ -382,9 +450,14 @@
 		}
 		
 		// Engineer - Primary
+		"9" // Engineer's Shotgun
+		{
+			"variants" "199;1141;15003;15016;15044;15047;15085;15109;15132;15133;15152"
+		}
 		"141" // Frontier Justice 
 		{
 			"cost" "950"
+			"variants" "1004"
 		}
 		"527" // Widowmaker
 		{
@@ -400,9 +473,14 @@
 		}
 		
 		// Engineer - Secondary
+		"22" // Engineer's Pistol
+		{
+			"variants" "209;160;294;15013;15018;15035;15041;15046;15056;15060;15061;15100;15101;15102;15126;15148;30666"
+		}
 		"140" // Wrangler
 		{
 			"cost" "1350"
+			"variants" "1086;30668"
 		}
 		"528" // Short Circuit
 		{
@@ -410,6 +488,10 @@
 		}
 		
 		// Engineer - Melee
+		"7" // Wrench
+		{
+			"variants" "197;169;662;795;804;884;893;902;911;960;969;15073;15074;15075;15139;15140;15114;15156"
+		}
 		"142" // Gunslinger
 		{
 			"cost" "2650"
@@ -431,6 +513,7 @@
 		"25" // Construction PDA
 		{
 			"cost" "2500"
+			"variant" "737"
 		}
 		"26" // Destruction PDA
 		{
@@ -438,6 +521,10 @@
 		}
 		
 		// Medic - Primary
+		"17"
+		{
+			"variants" "204"
+		}
 		"36" // Blutsauger
 		{
 			"cost" "800"
@@ -445,6 +532,7 @@
 		"305" // Crusader's Crossbow
 		{
 			"cost" "1450"
+			"variants" "1079"
 		}
 		"412" // Overdose
 		{
@@ -455,6 +543,7 @@
 		"29" // Medi Gun
 		{
 			"cost" "4250"
+			"variants" "211;663;796;805;885;894;903;912;961;970;15008;15010;15025;15039;15050;15078;15097;15121;15122;15123;15145;15146"
 		}
 		"35" // Kritzkrieg
 		{
@@ -470,9 +559,14 @@
 		}
 		
 		// Medic - Melee
+		"8" // Bonesaw
+		{
+			"variants" "198;1143"
+		}
 		"37" // Ubersaw
 		{
 			"cost" "1150"
+			"variants" "1003"
 		}
 		"173" // Vita-Saw 
 		{
@@ -488,6 +582,10 @@
 		}
 		
 		// Sniper - Primary
+		"14" // Sniper Rifle
+		{
+			"variants" "201;664;792;801;881;890;899;908;957;966;15000;15007;15019;15023;15033;15059;15070;15071;15072;15111;15112;15135;15136;15154"
+		}
 		"851" // AWPer Hand
 		{
 			"cost" "3750"
@@ -503,6 +601,7 @@
 		"526" // Machina
 		{
 			"cost" "3750"
+			"variants" "30665"
 		}
 		"752" // Hitman's Heatmaker
 		{
@@ -515,12 +614,18 @@
 		"56" // Huntsman
 		{
 			"cost" "3200"
+			"variants" "1005;1092"
 		}
 		
 		// Sniper - Secondary
+		"16" // SMG
+		{
+			"variants" "203;1149;15001;15022;15032;15037;15058;15076;15110;15134;15153"
+		}
 		"58" // Jarate
 		{
 			"cost" "950"
+			"variants" "1083;1105"
 		}
 		"57" // Razorback
 		{
@@ -540,6 +645,10 @@
 		}
 		
 		// Sniper - Melee
+		"3" // Kukri
+		{
+			"variants" "193"
+		}
 		"171" // Tribalman's Shiv 
 		{
 			"cost" "800"
@@ -557,10 +666,12 @@
 		"24" // Revolver
 		{
 			"cost" "1700"
+			"variants" "210;161;1142;15011;15027;15042;15051;15062;15063;15064;15103;15128;15129;15149"
 		}
 		"61" // Ambassador
 		{
 			"cost" "1800"
+			"variants" "1006"
 		}
 		"224" // L'Etranger
 		{
@@ -576,15 +687,25 @@
 		}
 		
 		// Spy - Building (Sapper)
+		"735" // Sapper
+		{
+			"variants" "736;933;1080;1102"
+		}
 		"810" // The Red-Tape Recorder
 		{
 			"cost" "400"
+			"variants" "831"
 		}
 		
 		// Spy - Melee
+		"4" // Knife
+		{
+			"variants" "194;638;665;727;794;803;883;892;901;910;959;968;15062;15094;15095;15096;15118;15119;15143;151442"
+		}
 		"225" // Your Eternal Reward
 		{
 			"cost" "2450"
+			"variants" "574"
 		}
 		"356" // Conniver's Kunai
 		{
@@ -606,6 +727,10 @@
 		}
 		
 		// Spy - PDA2
+		"30" // Invis Watch
+		{
+			"variants" "212;297;947"
+		}
 		"59" // Dead Ringer
 		{
 			"cost" "2850"

--- a/addons/sourcemod/scripting/tfgo/config.sp
+++ b/addons/sourcemod/scripting/tfgo/config.sp
@@ -49,7 +49,7 @@ public void ReadWeaponConfig(KeyValues kv)
 					
 					for (int i = 0; i < sizeof(buffers); i++)
 					{
-						int variantDefIndex = StringToInt(buffers[i]);
+						int variantDefIndex = StringToInt(TrimString(buffers[i]));
 						if (variantDefIndex > -1)
 							variantList.Push(variantDefIndex);
 					}

--- a/addons/sourcemod/scripting/tfgo/config.sp
+++ b/addons/sourcemod/scripting/tfgo/config.sp
@@ -44,15 +44,11 @@ public void ReadWeaponConfig(KeyValues kv)
 				if (strlen(variantsString) > 0)
 				{
 					char buffers[32][256]; // max. 32 variants
-					for (int i = 0; i < sizeof(buffers); i++)buffers[i] = "-1"; // because 0 = Bat
-					ExplodeString(variantsString, ";", buffers, sizeof(buffers), sizeof(buffers[]));
-					
-					for (int i = 0; i < sizeof(buffers); i++)
+					int numVariants = ExplodeString(variantsString, ";", buffers, sizeof(buffers), sizeof(buffers[]));
+					for (int i = 0; i < numVariants; i++)
 					{
 						TrimString(buffers[i]);
-						int variantDefIndex = StringToInt(buffers[i]);
-						if (variantDefIndex > -1)
-							variantList.Push(variantDefIndex);
+						variantList.Push(StringToInt(buffers[i]));
 					}
 				}
 				weapon.variants = variantList;

--- a/addons/sourcemod/scripting/tfgo/config.sp
+++ b/addons/sourcemod/scripting/tfgo/config.sp
@@ -6,6 +6,7 @@ enum struct Weapon
 	int defindex;
 	int cost;
 	int killAward;
+	ArrayList variants;
 }
 
 StringMap g_weaponClassKillAwards;
@@ -30,11 +31,30 @@ public void ReadWeaponConfig(KeyValues kv)
 				int killAward = kv.GetNum("killAward", -1);
 				if (killAward <= -1)
 				{
-					char class[255];
+					char class[256];
 					TF2Econ_GetItemClassName(weapon.defindex, class, sizeof(class));
 					g_weaponClassKillAwards.GetValue(class, killAward);
 				}
 				weapon.killAward = killAward;
+				
+				// Variants
+				char variantsString[256];
+				kv.GetString("variants", variantsString, sizeof(variantsString));
+				ArrayList variantList = new ArrayList();
+				if (strlen(variantsString) > 0)
+				{
+					char buffers[32][256]; // max. 32 variants
+					for (int i = 0; i < sizeof(buffers); i++)buffers[i] = "-1"; // because 0 = Bat
+					ExplodeString(variantsString, ";", buffers, sizeof(buffers), sizeof(buffers[]));
+					
+					for (int i = 0; i < sizeof(buffers); i++)
+					{
+						int variantDefIndex = StringToInt(buffers[i]);
+						if (variantDefIndex > -1)
+							variantList.Push(variantDefIndex);
+					}
+				}
+				weapon.variants = variantList;
 				
 				int length = g_availableWeapons.Length;
 				g_availableWeapons.Resize(length + 1);

--- a/addons/sourcemod/scripting/tfgo/config.sp
+++ b/addons/sourcemod/scripting/tfgo/config.sp
@@ -49,7 +49,8 @@ public void ReadWeaponConfig(KeyValues kv)
 					
 					for (int i = 0; i < sizeof(buffers); i++)
 					{
-						int variantDefIndex = StringToInt(TrimString(buffers[i]));
+						TrimString(buffers[i]);
+						int variantDefIndex = StringToInt(buffers[i]);
 						if (variantDefIndex > -1)
 							variantList.Push(variantDefIndex);
 					}

--- a/addons/sourcemod/scripting/tfgo/config.sp
+++ b/addons/sourcemod/scripting/tfgo/config.sp
@@ -85,6 +85,27 @@ void ReadKillAwardConfig(KeyValues kv)
 	}
 }
 
+public int GetBaseWeaponForVariant(int defindex)
+{
+	if (g_availableWeapons.FindValue(defindex, 0) > -1)
+		return defindex;
+	
+	for (int i = 0; i < g_availableWeapons.Length; i++)
+	{
+		Weapon weapon;
+		g_availableWeapons.GetArray(i, weapon, sizeof(weapon));
+		
+		ArrayList variants = weapon.variants;
+		for (int j = 0; j < variants.Length; j++)
+		{
+			if (defindex == variants.Get(j))
+				return weapon.defindex;
+		}
+	}
+	
+	return -1;
+}
+
 public int GetEffectiveKillAward(int defindex)
 {
 	int killAward;

--- a/addons/sourcemod/scripting/tfgo/methodmaps.sp
+++ b/addons/sourcemod/scripting/tfgo/methodmaps.sp
@@ -187,14 +187,15 @@ methodmap TFGOPlayer
 			if (defindex > -1)
 			{
 				// Check if player already has this weapon
-				if (defindex != TF2_GetItemInSlot(this.Client, slot))
+				int equippedWeapon = TF2_GetItemInSlot(this.Client, slot);
+				if (defindex != equippedWeapon)
 				{
 					int index = g_availableWeapons.FindValue(defindex, 0);
 					Weapon weapon;
 					g_availableWeapons.GetArray(index, weapon, sizeof(weapon));
 					
 					// Check if player already has a variant of this weapon
-					if (weapon.variants.FindValue(TF2_GetItemInSlot(this.Client, slot)) <= -1)
+					if (weapon.variants.FindValue(equippedWeapon) <= -1)
 					{
 						// If all else fails, equip the player with the weapon
 						TF2_CreateAndEquipWeapon(this.Client, defindex);

--- a/addons/sourcemod/scripting/tfgo/methodmaps.sp
+++ b/addons/sourcemod/scripting/tfgo/methodmaps.sp
@@ -184,12 +184,26 @@ methodmap TFGOPlayer
 		for (int slot = sizeof(g_playerLoadoutWeaponIndexes[][]) - 1; slot >= 0; slot--)
 		{
 			int defindex = this.GetWeaponFromLoadout(class, slot);
-			if (defindex != TF2_GetItemInSlot(this.Client, slot))
+			if (defindex > -1)
 			{
-				if (defindex != -1)
-					TF2_CreateAndEquipWeapon(this.Client, defindex);
-				else
-					TF2_RemoveItemInSlot(this.Client, slot);
+				// Check if player already has this weapon
+				if (defindex != TF2_GetItemInSlot(this.Client, slot))
+				{
+					int index = g_availableWeapons.FindValue(defindex, 0);
+					Weapon weapon;
+					g_availableWeapons.GetArray(index, weapon, sizeof(weapon));
+					
+					// Check if player already has a variant of this weapon
+					if (weapon.variants.FindValue(TF2_GetItemInSlot(this.Client, slot)) <= -1)
+					{
+						// If all else fails, equip the player with the weapon
+						TF2_CreateAndEquipWeapon(this.Client, defindex);
+					}
+				}
+			}
+			else
+			{
+				TF2_RemoveItemInSlot(this.Client, slot);
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/tfgo/methodmaps.sp
+++ b/addons/sourcemod/scripting/tfgo/methodmaps.sp
@@ -136,7 +136,8 @@ methodmap TFGOPlayer
 		int slot = TF2_GetSlotInItem(defindex, class);
 		
 		// Player doesn't own weapon yet, charge them for it and grant it
-		if (g_playerLoadoutWeaponIndexes[this][class][slot] != defindex)
+		int loadoutIndex = g_playerLoadoutWeaponIndexes[this][class][slot];
+		if (GetBaseWeaponForVariant(loadoutIndex) != defindex)
 		{
 			TF2_CreateAndEquipWeapon(this.Client, defindex);
 			
@@ -183,24 +184,13 @@ methodmap TFGOPlayer
 		
 		for (int slot = sizeof(g_playerLoadoutWeaponIndexes[][]) - 1; slot >= 0; slot--)
 		{
-			int defindex = this.GetWeaponFromLoadout(class, slot);
-			if (defindex > -1)
+			int loadoutIndex = this.GetWeaponFromLoadout(class, slot);
+			int equippedIndex = TF2_GetItemInSlot(this.Client, slot);
+			if (loadoutIndex > -1)
 			{
-				// Check if player already has this weapon
-				int equippedWeapon = TF2_GetItemInSlot(this.Client, slot);
-				if (defindex != equippedWeapon)
-				{
-					int index = g_availableWeapons.FindValue(defindex, 0);
-					Weapon weapon;
-					g_availableWeapons.GetArray(index, weapon, sizeof(weapon));
-					
-					// Check if player already has a variant of this weapon
-					if (weapon.variants.FindValue(equippedWeapon) <= -1)
-					{
-						// If all else fails, equip the player with the weapon
-						TF2_CreateAndEquipWeapon(this.Client, defindex);
-					}
-				}
+				// Equip the player with the saved weapon if they don't already have an equal one equipped
+				if (GetBaseWeaponForVariant(loadoutIndex) != GetBaseWeaponForVariant(equippedIndex))
+					TF2_CreateAndEquipWeapon(this.Client, loadoutIndex);
 			}
 			else
 			{


### PR DESCRIPTION
Every stock weapon and some unlocks have different variants (Festive, Botkiller, Decorated, etc.). Since they are mechnically equal, it makes sense to treat them as the same weapon.

This PR aims to allow players to spawn with the currently equipped weapon from their backpack (e.g. if you currently have an Australium SMG equipped, the gamemode *won't* attempt to give you a stock SMG).

This applies to all weapons, but can only take effect after a respawn or after suiciding during the pre-round time.

Relevant issue: #14 