### PR TITLE
Patch weapon pickups in respawn rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ All players start with basic weaponry and can buy new gear at the start of each 
 
 ## Dependencies
 * SourceMod 1.10
-* [DHooks](https://forums.alliedmods.net/showthread.php?t=180114)
+* [DHooks with Detour Support](https://forums.alliedmods.net/showpost.php?p=2588686&postcount=589)
 * [TF2 Econ Data](https://forums.alliedmods.net/showthread.php?t=315011)
 * [More Colors](https://forums.alliedmods.net/showthread.php?t=185016)
+* [MemoryPatch](https://github.com/Kenzzer/MemoryPatch)
 
 ## Compatible Maps
 Any arena map that doesn't do wacky stuff should be compatible with this gamemode.  

--- a/addons/sourcemod/gamedata/tfgo.txt
+++ b/addons/sourcemod/gamedata/tfgo.txt
@@ -71,5 +71,29 @@
 				"linux"		"161"
 			}
 		}
+		"Addresses"
+		{
+			"Patch_PickupWeaponFromOther"
+			{
+				"linux"
+				{
+					"signature"	"CTFPlayer::PickupWeaponFromOther"
+					"offset" "405" // 0x195
+				}
+				"windows"
+				{
+					"signature"	"CTFPlayer::PickupWeaponFromOther"
+					"offset" "282" // 0x11A
+				}
+			}
+		}
+		"Keys"
+		{
+			"Patch_PickupWeaponFromOther"
+			{
+				"windows"	"\xEB"
+				"linux"		"\x90\x90\x90\x90\x90\x90\x90\x90"
+			}
+		} 
 	}
 }

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -7,6 +7,7 @@
 #include <tf2_stocks>
 #include <tf_econ_data>
 #include <dhooks>
+#include <memorypatch>
 
 #pragma newdecls required
 
@@ -25,6 +26,7 @@ Handle g_bombDetonationWarningTimer;
 Handle g_bombBeepingTimer;
 
 // Other handles
+MemoryPatch g_pickupWepPatch;
 Handle g_hudSync;
 StringMap g_availableMusicKits;
 ArrayList g_availableWeapons;
@@ -166,6 +168,7 @@ public void OnPluginStart()
 public void OnPluginEnd()
 {
 	Toggle_ConVars(false);
+	g_pickupWepPatch.Disable();
 }
 
 public void OnMapStart()
@@ -908,6 +911,11 @@ void SDK_Init()
 	g_SDKInitDroppedWeapon = EndPrepSDKCall();
 	if (g_SDKInitDroppedWeapon == null)
 		LogMessage("Failed to create call: CTFDroppedWeapon::InitDroppedWeapon");
+	
+	MemoryPatch.SetGameData(config);
+	g_pickupWepPatch = new MemoryPatch("Patch_PickupWeaponFromOther");
+	if (g_pickupWepPatch != null)
+		g_pickupWepPatch.Enable();
 	
 	delete config;
 }


### PR DESCRIPTION
If you pick up a dropped weapon while in a respawn room, TF2 will not generate a new one. Since CS:GO allows swapping your weapon with another on the ground inside the buy zone, it seems only reasonable to also allow this in the gamemode.

For performance reasons, a memory patch is used instead of detouring ``PointInRespawnRoom``.