### PR TITLE
Use translation files for cash award messages

### DIFF
--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -425,10 +425,10 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 						if (!IsClientInGame(client))
 							continue;
 						
-						if (GetClientTeam(client) == GetClientTeam(victim.Client))
-							PrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_EnemyGotCash", LANG_SERVER, victimName);
-						else if (TF2_GetClientTeam(client) == TFTeam_Spectator)
+						if (TF2_GetClientTeam(client) == TFTeam_Spectator)
 							PrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_Spectators", LANG_SERVER, attackerName, killAward, victimName);
+						else if (GetClientTeam(client) == GetClientTeam(victim.Client))
+							PrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_EnemyGotCash", LANG_SERVER, victimName);
 						else if (attacker.Client != client)
 							CPrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_TeammateGotCash", LANG_SERVER, attackerName, killAward, victimName);
 					}

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -47,6 +47,7 @@ bool g_isBombDetonated;
 bool g_isBombDefused;
 float g_bombPlantedTime;
 TFTeam g_bombPlantingTeam;
+bool g_playerSuicides[TF_MAXPLAYERS + 1];
 
 // ConVars
 ConVar tfgo_buytime;
@@ -330,8 +331,8 @@ public MRESReturn Hook_SetWinningTeam(Handle params)
 	{
 		TFGOTeam red = TFGOTeam(TFTeam_Red);
 		TFGOTeam blue = TFGOTeam(TFTeam_Blue);
-		red.AddToClientBalances(0, "No income for running out of time and surviving.");
-		blue.AddToClientBalances(0, "No income for running out of time and surviving.");
+		red.AddToClientBalances(0, "%T", "Team_Cash_Award_no_income", LANG_SERVER);
+		blue.AddToClientBalances(0, "%T", "Team_Cash_Award_no_income", LANG_SERVER);
 		red.LoseStreak++;
 		blue.LoseStreak++;
 		return MRES_Ignored;
@@ -393,7 +394,7 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 		char classname[PLATFORM_MAX_PATH];
 		if (IsValidEntity(inflictorEntindex) && GetEntityClassname(inflictorEntindex, classname, sizeof(classname)) && g_weaponClassKillAwards.GetValue(classname, killAward))
 		{
-			attacker.AddToBalance(RoundFloat(killAward * factor), "Award for neutralizing an enemy.");
+			attacker.AddToBalance(RoundFloat(killAward * factor), "%T", "Player_Cash_Award_Killed_Enemy_Generic", LANG_SERVER);
 		}
 		else
 		{
@@ -401,6 +402,7 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 			{
 				if (g_isMainRoundActive)
 				{
+					g_playerSuicides[victim.Client] = true;
 					killAward = RoundFloat(tfgo_cash_player_killed_enemy_default.IntValue * factor);
 					
 					// Re-assign attacker to random enemy player
@@ -413,6 +415,10 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 					attacker = TFGOPlayer(enemies.Get(GetRandomInt(0, enemies.Length - 1)));
 					delete enemies;
 					
+					
+					char attackerName[PLATFORM_MAX_PATH];
+					GetClientName(attacker.Client, attackerName, sizeof(attackerName));
+					
 					// CS:GO does special chat messages for suicides
 					for (int client = 1; client <= MaxClients; client++)
 					{
@@ -420,19 +426,15 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 							continue;
 						
 						if (GetClientTeam(client) == GetClientTeam(victim.Client))
-						{
-							PrintToChat(client, "An enemy player was awarded compensation for the suicide of %s.", victimName);
-						}
+							PrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_EnemyGotCash", LANG_SERVER, victimName);
+						else if (TF2_GetClientTeam(client) == TFTeam_Spectator)
+							PrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_Spectators", LANG_SERVER, attackerName, killAward, victimName);
 						else if (attacker.Client != client)
-						{
-							char attackerName[PLATFORM_MAX_PATH];
-							GetClientName(attacker.Client, attackerName, sizeof(attackerName));
-							CPrintToChat(client, "Your teammate %s was awarded {positive}$%d {default}compensation for the suicide of %s.", attackerName, killAward, victimName);
-						}
+							CPrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_TeammateGotCash", LANG_SERVER, attackerName, killAward, victimName);
 					}
 					
-					attacker.AddToBalance(killAward, "Award for neutralizing an enemy.", victimName);
-					PrintToChat(attacker.Client, "(You were awarded $%d compensation for the suicide of %s)", killAward, victimName);
+					attacker.AddToBalance(killAward, "%T", "Player_Cash_Award_Killed_Enemy_Generic", LANG_SERVER, victimName);
+					PrintToChat(attacker.Client, "%T", "Player_Cash_Award_ExplainSuicide_YouGotCash", LANG_SERVER, killAward, victimName);
 				}
 			}
 			else // Weapon kill
@@ -453,7 +455,7 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 						killAward = tfgo_cash_player_killed_enemy_default.IntValue;
 				}
 				
-				attacker.AddToBalance(RoundFloat(killAward * factor), "Award for neutralizing an enemy with %s.", weaponName);
+				attacker.AddToBalance(RoundFloat(killAward * factor), "%T", "Player_Cash_Award_Killed_Enemy", LANG_SERVER, weaponName);
 			}
 		}
 		
@@ -474,7 +476,7 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 				killAward = tfgo_cash_player_killed_enemy_default.IntValue;
 			}
 			
-			assister.AddToBalance(RoundFloat(killAward * factor) / 2, "Award for assisting in neutralizing %s.", victimName);
+			assister.AddToBalance(RoundFloat(killAward * factor) / 2, "%T", "Player_Cash_Award_Assist_Enemy", LANG_SERVER, victimName);
 		}
 	}
 	
@@ -542,7 +544,7 @@ public Action OnBuyTimeExpire(Handle timer)
 			if (player.ActiveBuyMenu != null)
 			{
 				player.ActiveBuyMenu.Cancel();
-				PrintHintText(client, "%T", "#BuyMenu_OutOfTime", LANG_SERVER, tfgo_buytime.IntValue);
+				PrintHintText(client, "%T", "BuyMenu_OutOfTime", LANG_SERVER, tfgo_buytime.IntValue);
 			}
 		}
 	}
@@ -591,7 +593,7 @@ void PlantBomb(TFTeam team, int cp, ArrayList cappers)
 	for (int i = 0; i < cappers.Length; i++)
 	{
 		int capper = cappers.Get(i);
-		TFGOPlayer(capper).AddToBalance(tfgo_cash_player_bomb_planted.IntValue, "Award for planting the bomb.");
+		TFGOPlayer(capper).AddToBalance(tfgo_cash_player_bomb_planted.IntValue, "%T", "Player_Cash_Award_Bomb_Planted", LANG_SERVER);
 	}
 	
 	// Superceding SetWinningTeam causes arena mode to force a map change on capture
@@ -738,7 +740,7 @@ void DefuseBomb(TFTeam team, ArrayList cappers)
 	for (int i = 0; i < cappers.Length; i++)
 	{
 		int capper = cappers.Get(i);
-		TFGOPlayer(capper).AddToBalance(tfgo_cash_player_bomb_defused.IntValue, "Award for defusing the bomb.");
+		TFGOPlayer(capper).AddToBalance(tfgo_cash_player_bomb_defused.IntValue, "%T", "Player_Cash_Award_Bomb_Defused", LANG_SERVER);
 	}
 	
 	g_isBombDefused = true;
@@ -769,20 +771,30 @@ public Action Event_Arena_Win_Panel(Event event, const char[] name, bool dontBro
 	{
 		if (g_bombPlantingTeam == view_as<TFTeam>(event.GetInt("winning_team")))
 		{
-			winningTeam.AddToClientBalances(tfgo_cash_team_terrorist_win_bomb.IntValue, "Team award for detonating bomb.");
+			winningTeam.AddToClientBalances(tfgo_cash_team_terrorist_win_bomb.IntValue, "%T", "Team_Cash_Award_T_Win_Bomb", LANG_SERVER);
 		}
 		else
 		{
-			winningTeam.AddToClientBalances(tfgo_cash_team_win_by_defusing_bomb.IntValue, "Team award for winning by defusing the bomb.");
-			losingTeam.AddToClientBalances(tfgo_cash_team_planted_bomb_but_defused.IntValue, "Team award for planting the bomb.");
+			winningTeam.AddToClientBalances(tfgo_cash_team_win_by_defusing_bomb.IntValue, "%T", "Team_Cash_Award_Win_Defuse_Bomb", LANG_SERVER);
+			losingTeam.AddToClientBalances(tfgo_cash_team_planted_bomb_but_defused.IntValue, "%T", "Team_Cash_Award_Planted_Bomb_But_Defused", LANG_SERVER);
 		}
 	}
 	else if (winreason == Winreason_Elimination)
 	{
-		winningTeam.AddToClientBalances(tfgo_cash_team_elimination.IntValue, "Team award for eliminating the enemy team.");
+		winningTeam.AddToClientBalances(tfgo_cash_team_elimination.IntValue, "%T", "Team_Cash_Award_Elim_Bomb", LANG_SERVER);
 	}
 	
-	losingTeam.AddToClientBalances(losingTeam.LoseIncome, "Income for losing.");
+	for (int client = 1; client <= MaxClients; client++)
+	{
+		if (IsClientInGame(client) && TF2_GetClientTeam(client) == losingTeam.Team)
+		{
+			// Do not give losing bonus to players that deliberately suicided
+			if (g_playerSuicides[client])
+				TFGOPlayer(client).AddToBalance(0, "%T", "Team_Cash_Award_no_income_suicide", LANG_SERVER);
+			else
+				TFGOPlayer(client).AddToBalance(losingTeam.LoseIncome, "%T", "Team_Cash_Award_Loser_Bonus", LANG_SERVER);
+		}
+	}
 	
 	// Adjust team losing streaks
 	losingTeam.LoseStreak++;
@@ -802,6 +814,7 @@ public void ResetGameState()
 	g_isBombDetonated = false;
 	g_isBombDefused = false;
 	g_bombPlantingTeam = TFTeam_Unassigned;
+	for (int i = 0; i < sizeof(g_playerSuicides); i++)g_playerSuicides[i] = false;
 }
 
 public Action Event_Arena_Match_MaxStreak(Event event, const char[] name, bool dontBroadcast)

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -405,36 +405,40 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 					g_playerSuicides[victim.Client] = true;
 					killAward = RoundFloat(tfgo_cash_player_killed_enemy_default.IntValue * factor);
 					
-					// Re-assign attacker to random enemy player
 					ArrayList enemies = new ArrayList();
 					for (int client = 1; client <= MaxClients; client++)
 					{
-						if (IsClientInGame(client) && IsPlayerAlive(client) && GetClientTeam(client) != GetClientTeam(attacker.Client))
+						if (IsClientInGame(client) && IsPlayerAlive(client) && GetClientTeam(client) != GetClientTeam(victim.Client))
 							enemies.Push(client);
 					}
-					attacker = TFGOPlayer(enemies.Get(GetRandomInt(0, enemies.Length - 1)));
-					delete enemies;
 					
-					
-					char attackerName[PLATFORM_MAX_PATH];
-					GetClientName(attacker.Client, attackerName, sizeof(attackerName));
-					
-					// CS:GO does special chat messages for suicides
-					for (int client = 1; client <= MaxClients; client++)
+					// Re-assign attacker to random enemy player, if present
+					if (enemies.Length > 0)
 					{
-						if (!IsClientInGame(client))
-							continue;
+						attacker = TFGOPlayer(enemies.Get(GetRandomInt(0, enemies.Length - 1)));
 						
-						if (TF2_GetClientTeam(client) == TFTeam_Spectator)
-							PrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_Spectators", LANG_SERVER, attackerName, killAward, victimName);
-						else if (GetClientTeam(client) == GetClientTeam(victim.Client))
-							PrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_EnemyGotCash", LANG_SERVER, victimName);
-						else if (attacker.Client != client)
-							CPrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_TeammateGotCash", LANG_SERVER, attackerName, killAward, victimName);
+						char attackerName[PLATFORM_MAX_PATH];
+						GetClientName(attacker.Client, attackerName, sizeof(attackerName));
+						
+						// CS:GO does special chat messages for suicides
+						for (int client = 1; client <= MaxClients; client++)
+						{
+							if (!IsClientInGame(client))
+								continue;
+							
+							if (TF2_GetClientTeam(client) == TFTeam_Spectator)
+								PrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_Spectators", LANG_SERVER, attackerName, killAward, victimName);
+							else if (GetClientTeam(client) == GetClientTeam(victim.Client))
+								PrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_EnemyGotCash", LANG_SERVER, victimName);
+							else if (attacker.Client != client)
+								CPrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_TeammateGotCash", LANG_SERVER, attackerName, killAward, victimName);
+						}
+						
+						attacker.AddToBalance(killAward, "%T", "Player_Cash_Award_Killed_Enemy_Generic", LANG_SERVER, victimName);
+						PrintToChat(attacker.Client, "%T", "Player_Cash_Award_ExplainSuicide_YouGotCash", LANG_SERVER, killAward, victimName);
 					}
 					
-					attacker.AddToBalance(killAward, "%T", "Player_Cash_Award_Killed_Enemy_Generic", LANG_SERVER, victimName);
-					PrintToChat(attacker.Client, "%T", "Player_Cash_Award_ExplainSuicide_YouGotCash", LANG_SERVER, killAward, victimName);
+					delete enemies;
 				}
 			}
 			else // Weapon kill

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -426,7 +426,7 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 							if (!IsClientInGame(client))
 								continue;
 							
-							if (TF2_GetClientTeam(client) == TFTeam_Spectator)
+							if (TF2_GetClientTeam(client) <= TFTeam_Spectator)
 								PrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_Spectators", LANG_SERVER, attackerName, killAward, victimName);
 							else if (GetClientTeam(client) == GetClientTeam(victim.Client))
 								PrintToChat(client, "%T", "Player_Cash_Award_ExplainSuicide_EnemyGotCash", LANG_SERVER, victimName);

--- a/addons/sourcemod/scripting/tfgo/buymenu.sp
+++ b/addons/sourcemod/scripting/tfgo/buymenu.sp
@@ -1,31 +1,31 @@
 public void DisplaySlotSelectionMenu(int client)
 {
 	Menu menu = new Menu(HandleSlotSelectionMenu, MenuAction_Display | MenuAction_Select | MenuAction_Cancel | MenuAction_End | MenuAction_DisplayItem);
-	menu.SetTitle("%T", "#BuyMenu_Title", LANG_SERVER, TFGOPlayer(client).Balance);
+	menu.SetTitle("%T", "BuyMenu_Title", LANG_SERVER, TFGOPlayer(client).Balance);
 	
 	switch (TF2_GetPlayerClass(client))
 	{
 		case TFClass_Engineer:
 		{
-			menu.AddItem("0", "#BuyMenu_Primary");
-			menu.AddItem("1", "#BuyMenu_Secondary");
-			menu.AddItem("2", "#BuyMenu_Melee");
-			menu.AddItem("3;4", "#BuyMenu_PDA");
+			menu.AddItem("0", "BuyMenu_Primary");
+			menu.AddItem("1", "BuyMenu_Secondary");
+			menu.AddItem("2", "BuyMenu_Melee");
+			menu.AddItem("3;4", "BuyMenu_PDA");
 		}
 		
 		case TFClass_Spy:
 		{
-			menu.AddItem("0", "#BuyMenu_Secondary"); // Revolver
-			menu.AddItem("2", "#BuyMenu_Melee"); // Knife
-			menu.AddItem("3;4", "#BuyMenu_PDA"); // Disguise Kit/Invis Watch
-			//menu.AddItem("1", "#BuyMenu_Building_Spy"); // Sapper (Currently crashes the game)
+			menu.AddItem("0", "BuyMenu_Secondary"); // Revolver
+			menu.AddItem("2", "BuyMenu_Melee"); // Knife
+			menu.AddItem("3;4", "BuyMenu_PDA"); // Disguise Kit/Invis Watch
+			//menu.AddItem("1", "BuyMenu_Building_Spy"); // Sapper (Currently crashes the game)
 		}
 		
 		default:
 		{
-			menu.AddItem("0", "#BuyMenu_Primary");
-			menu.AddItem("1", "#BuyMenu_Secondary");
-			menu.AddItem("2", "#BuyMenu_Melee");
+			menu.AddItem("0", "BuyMenu_Primary");
+			menu.AddItem("1", "BuyMenu_Secondary");
+			menu.AddItem("2", "BuyMenu_Melee");
 		}
 	}
 	
@@ -78,7 +78,7 @@ public int HandleSlotSelectionMenu(Menu menu, MenuAction action, int param1, int
 public void DisplayBuyMenu(int client, ArrayList slots)
 {
 	Menu menu = new Menu(HandleBuyMenu, MenuAction_Display | MenuAction_Select | MenuAction_Cancel | MenuAction_End | MenuAction_DrawItem);
-	menu.SetTitle("%T", "#BuyMenu_Title", LANG_SERVER, TFGOPlayer(client).Balance);
+	menu.SetTitle("%T", "BuyMenu_Title", LANG_SERVER, TFGOPlayer(client).Balance);
 	
 	for (int i = 0; i < g_availableWeapons.Length; i++)
 	{

--- a/addons/sourcemod/scripting/tfgo/buyzone.sp
+++ b/addons/sourcemod/scripting/tfgo/buyzone.sp
@@ -68,7 +68,7 @@ public Action Hook_OnEndTouchBuyZone(int entity, int client)
 		if (player.ActiveBuyMenu != null)
 		{
 			player.ActiveBuyMenu.Cancel();
-			PrintHintText(client, "%T", "#BuyMenu_NotInBuyZone", LANG_SERVER);
+			PrintHintText(client, "%T", "BuyMenu_NotInBuyZone", LANG_SERVER);
 		}
 	}
 }
@@ -96,7 +96,7 @@ public void DisplayMenuInDynamicBuyZone(int client)
 			if (player.ActiveBuyMenu != null)
 			{
 				player.ActiveBuyMenu.Cancel();
-				PrintHintText(client, "%T", "#BuyMenu_NotInBuyZone", LANG_SERVER);
+				PrintHintText(client, "%T", "BuyMenu_NotInBuyZone", LANG_SERVER);
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/tfgo/methodmaps.sp
+++ b/addons/sourcemod/scripting/tfgo/methodmaps.sp
@@ -218,6 +218,6 @@ methodmap TFGOTeam
 		
 		for (int client = 1; client <= MaxClients; client++)
 			if (IsClientInGame(client) && TF2_GetClientTeam(client) == this.Team)
-				TFGOPlayer(client).AddToBalance(val, reason);
+				TFGOPlayer(client).AddToBalance(val, message);
 	}
 }

--- a/addons/sourcemod/scripting/tfgo/methodmaps.sp
+++ b/addons/sourcemod/scripting/tfgo/methodmaps.sp
@@ -211,8 +211,11 @@ methodmap TFGOTeam
 		g_teamLosingStreaks[this] = TFGO_STARTING_LOSESTREAK;
 	}
 	
-	public void AddToClientBalances(int val, const char[] reason)
+	public void AddToClientBalances(int val, const char[] reason, any...)
 	{
+		char message[PLATFORM_MAX_PATH];
+		VFormat(message, sizeof(message), reason, 4);
+		
 		for (int client = 1; client <= MaxClients; client++)
 			if (IsClientInGame(client) && TF2_GetClientTeam(client) == this.Team)
 				TFGOPlayer(client).AddToBalance(val, reason);

--- a/addons/sourcemod/translations/tfgo.phrases.txt
+++ b/addons/sourcemod/translations/tfgo.phrases.txt
@@ -175,7 +175,7 @@
 	}
 	"Player_Cash_Award_ExplainSuicide_TeammateGotCash"
 	{
-		"en"	"Your teammate %s was awarded ${positive}+$%d{default} compensation for the suicide of %s."
+		"en"	"Your teammate %s was awarded {positive}$+$%d{default} compensation for the suicide of %s."
 	}
 	"Player_Cash_Award_ExplainSuicide_EnemyGotCash"
 	{

--- a/addons/sourcemod/translations/tfgo.phrases.txt
+++ b/addons/sourcemod/translations/tfgo.phrases.txt
@@ -171,11 +171,11 @@
 	}
 	"Player_Cash_Award_ExplainSuicide_YouGotCash"
 	{
-		"en"	"(You were awarded +$%s compensation for the suicide of %s)"
+		"en"	"(You were awarded +$%d compensation for the suicide of %s)"
 	}
 	"Player_Cash_Award_ExplainSuicide_TeammateGotCash"
 	{
-		"en"	"Your teammate %s was awarded ${positive}+$%s{default} compensation for the suicide of %s."
+		"en"	"Your teammate %s was awarded ${positive}+$%d{default} compensation for the suicide of %s."
 	}
 	"Player_Cash_Award_ExplainSuicide_EnemyGotCash"
 	{
@@ -183,7 +183,7 @@
 	}
 	"Player_Cash_Award_ExplainSuicide_Spectators"
 	{
-		"en"	"%s was awarded +$%s compensation for the suicide of %s."
+		"en"	"%s was awarded +$%d compensation for the suicide of %s."
 	}
 	
 	// Team Cash Awards

--- a/addons/sourcemod/translations/tfgo.phrases.txt
+++ b/addons/sourcemod/translations/tfgo.phrases.txt
@@ -148,6 +148,7 @@
 		"en"	"The %d second buy period has expired"
 	}
 	
+	// Player Cash Awards
 	"Player_Cash_Award_Killed_Enemy_Generic"
 	{
 		"en"	"Award for neutralizing an enemy."
@@ -168,8 +169,6 @@
 	{
 		"en"	"Award for defusing the bomb."
 	}
-	
-	// Player Cash Awards
 	"Player_Cash_Award_ExplainSuicide_YouGotCash"
 	{
 		"en"	"(You were awarded +$%s compensation for the suicide of %s)"

--- a/addons/sourcemod/translations/tfgo.phrases.txt
+++ b/addons/sourcemod/translations/tfgo.phrases.txt
@@ -114,37 +114,106 @@
 		"en"	"Invis Watch"
 	}
 	
-	// Buy Menu Translations
-	"#BuyMenu_Title"
+	// Buy Menu
+	"BuyMenu_Title"
 	{
 		"en"	"Welcome to the buy menu!\nYou currently have $%d."
 	}
-	"#BuyMenu_Primary"
+	"BuyMenu_Primary"
 	{
 		"en"	"Primary Weapon"
 	}
-	"#BuyMenu_Secondary"
+	"BuyMenu_Secondary"
 	{
 		"en"	"Secondary Weapon"
 	}
-	"#BuyMenu_Melee"
+	"BuyMenu_Melee"
 	{
 		"en"	"Melee Weapon"
 	}
-	"#BuyMenu_PDA"
+	"BuyMenu_PDA"
 	{
 		"en"	"PDA"
 	}
-	"#BuyMenu_Building_Spy"
+	"BuyMenu_Building_Spy"
 	{
 		"en"	"Sapper"
 	}
-	"#BuyMenu_NotInBuyZone"
+	"BuyMenu_NotInBuyZone"
 	{
 		"en"	"You have left the buy zone"
 	}
-	"#BuyMenu_OutOfTime"
+	"BuyMenu_OutOfTime"
 	{
 		"en"	"The %d second buy period has expired"
+	}
+	
+	"Player_Cash_Award_Killed_Enemy_Generic"
+	{
+		"en"	"Award for neutralizing an enemy."
+	}
+	"Player_Cash_Award_Killed_Enemy"
+	{
+		"en"	"Award for neutralizing an enemy with %s."
+	}
+	"Player_Cash_Award_Assist_Enemy"
+	{
+		"en"	"Award for assisting in neutralizing %s."
+	}
+	"Player_Cash_Award_Bomb_Planted"
+	{
+		"en"	"Award for planting the bomb."
+	}
+	"Player_Cash_Award_Bomb_Defused"
+	{
+		"en"	"Award for defusing the bomb."
+	}
+	
+	// Player Cash Awards
+	"Player_Cash_Award_ExplainSuicide_YouGotCash"
+	{
+		"en"	"(You were awarded +$%s compensation for the suicide of %s)"
+	}
+	"Player_Cash_Award_ExplainSuicide_TeammateGotCash"
+	{
+		"en"	"Your teammate %s was awarded ${positive}+$%s{default} compensation for the suicide of %s."
+	}
+	"Player_Cash_Award_ExplainSuicide_EnemyGotCash"
+	{
+		"en"	"An enemy player was awarded compensation for the suicide of %s."
+	}
+	"Player_Cash_Award_ExplainSuicide_Spectators"
+	{
+		"en"	"%s was awarded +$%s compensation for the suicide of %s."
+	}
+	
+	// Team Cash Awards
+	"Team_Cash_Award_T_Win_Bomb"
+	{
+		"en"	"Team award for detonating bomb."
+	}
+	"Team_Cash_Award_Elim_Bomb"
+	{
+		"en"	"Team award for eliminating the enemy team."
+	}
+	"Team_Cash_Award_Win_Defuse_Bomb"
+	{
+		"en"	"Team award for winning by defusing the bomb."
+	}
+	"Team_Cash_Award_Loser_Bonus"
+	{
+		"en"	"Income for losing."
+	}
+	"Team_Cash_Award_Planted_Bomb_But_Defused"
+	{
+		"en"	"Team award for planting the bomb."
+	}
+	"Team_Cash_Award_no_income"
+	{
+		"en"	"No income for running out of time and surviving."
+	}
+	"Team_Cash_Award_no_income_suicide"
+	{
+		"en"	"No income for suiciding."
 	}
 }


### PR DESCRIPTION
Should make all of the different chat messages easier to maintain. Also allows translation of the gamemode, if we ever want that.

Messages mostly copied from ``csgo_english.txt`` with mentions of "C4" changed to "bomb".