### PR TITLE
Add pseudo StartTouch/EndTouch for calculated buyzone

### DIFF
--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -48,7 +48,7 @@ bool g_isBombDefused;
 float g_bombPlantedTime;
 TFTeam g_bombPlantingTeam;
 bool g_playerSuicides[TF_MAXPLAYERS + 1];
-bool g_playerExitedBuyMenu[TF_MAXPLAYERS + 1];
+bool g_playerInDynamicBuyZone[TF_MAXPLAYERS + 1];
 
 // ConVars
 ConVar tfgo_buytime;
@@ -496,6 +496,8 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 	if (g_isMainRoundActive || g_isBonusRoundActive)
 		victim.ClearLoadout();
 	
+	g_playerInDynamicBuyZone[victim.Client] = false;
+	
 	if (victim.ActiveBuyMenu != null)
 		victim.ActiveBuyMenu.Cancel();
 }
@@ -820,7 +822,7 @@ public void ResetGameState()
 	g_isBombDefused = false;
 	g_bombPlantingTeam = TFTeam_Unassigned;
 	for (int i = 0; i < sizeof(g_playerSuicides); i++)g_playerSuicides[i] = false;
-	for (int i = 0; i < sizeof(g_playerExitedBuyMenu); i++)g_playerExitedBuyMenu[i] = false;
+	for (int i = 0; i < sizeof(g_playerInDynamicBuyZone); i++)g_playerInDynamicBuyZone[i] = false;
 }
 
 public Action Event_Arena_Match_MaxStreak(Event event, const char[] name, bool dontBroadcast)

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -496,8 +496,6 @@ public Action Event_Player_Death(Event event, const char[] name, bool dontBroadc
 	if (g_isMainRoundActive || g_isBonusRoundActive)
 		victim.ClearLoadout();
 	
-	g_playerInDynamicBuyZone[victim.Client] = false;
-	
 	if (victim.ActiveBuyMenu != null)
 		victim.ActiveBuyMenu.Cancel();
 }
@@ -514,15 +512,17 @@ public Action Event_Post_Inventory_Application(Event event, const char[] name, b
 		if (player.ActiveBuyMenu != null)
 			player.ActiveBuyMenu.Cancel();
 		
-		// func_respawnroom OnStartTouch doesn't fire thus buy menu doesn't get re-opened so we do it manually
-		if (g_mapHasRespawnRoom)
-			DisplaySlotSelectionMenu(client);
+		// Open buy menu on respawn
+		DisplaySlotSelectionMenu(client);
 	}
 }
 
 public Action Event_Teamplay_Round_Start(Event event, const char[] name, bool dontBroadcast)
 {
-	g_isBombDetonated = false;
+	// Reset game state
+	ResetGameState();
+	
+	g_isBuyTimeActive = true;
 	g_isBonusRoundActive = false;
 	g_isMainRoundActive = false;
 	g_buyTimeTimer = CreateTimer(tfgo_buytime.FloatValue, OnBuyTimeExpire, _, TIMER_FLAG_NO_MAPCHANGE);
@@ -761,7 +761,6 @@ public Action Event_Arena_Win_Panel(Event event, const char[] name, bool dontBro
 {
 	g_isMainRoundActive = false;
 	g_isBonusRoundActive = true;
-	g_isBuyTimeActive = true;
 	
 	// Determine winning/losing team
 	TFGOTeam winningTeam = TFGOTeam(view_as<TFTeam>(event.GetInt("winning_team")));
@@ -810,9 +809,6 @@ public Action Event_Arena_Win_Panel(Event event, const char[] name, bool dontBro
 	// Reset timers
 	g_10SecondRoundTimer = null;
 	g_10SecondBombTimer = null;
-	
-	// Reset game state
-	ResetGameState();
 }
 
 public void ResetGameState()

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -233,7 +233,7 @@ public void OnClientPutInServer(int client)
 
 public void OnClientThink(int client)
 {
-	SetHudTextParams(0.05, 0.345, 0.1, 162, 255, 71, 255, _, 0.0, 0.0, 0.0);
+	SetHudTextParams(0.05, 0.325, 0.1, 162, 255, 71, 255, _, 0.0, 0.0, 0.0);
 	ShowHudText(client, -1, "$%d", TFGOPlayer(client).Balance);
 	
 	if (!g_mapHasRespawnRoom && g_isBuyTimeActive)

--- a/addons/sourcemod/scripting/tfgo/buymenu.sp
+++ b/addons/sourcemod/scripting/tfgo/buymenu.sp
@@ -58,12 +58,7 @@ public int HandleSlotSelectionMenu(Menu menu, MenuAction action, int param1, int
 			}
 		}
 		
-		case MenuAction_Cancel:
-		{
-			TFGOPlayer(param1).ActiveBuyMenu = null;
-			if (param2 == MenuCancel_Exit)
-				g_playerExitedBuyMenu[param1] = true;
-		}
+		case MenuAction_Cancel:TFGOPlayer(param1).ActiveBuyMenu = null;
 		
 		case MenuAction_End:delete menu;
 		
@@ -139,8 +134,6 @@ public int HandleBuyMenu(Menu menu, MenuAction action, int param1, int param2)
 			TFGOPlayer(param1).ActiveBuyMenu = null;
 			if (param2 == MenuCancel_ExitBack)
 				DisplaySlotSelectionMenu(param1);
-			else if (param2 == MenuCancel_Exit)
-				g_playerExitedBuyMenu[param1] = true;
 		}
 		
 		case MenuAction_End:delete menu;

--- a/addons/sourcemod/scripting/tfgo/buyzone.sp
+++ b/addons/sourcemod/scripting/tfgo/buyzone.sp
@@ -84,15 +84,16 @@ public void DisplayMenuInDynamicBuyZone(int client)
 		GetClientAbsOrigin(client, origin);
 		
 		float distance = GetVectorDistance(g_avgPlayerStartOrigin[team], origin);
-		
 		float radius = tfgo_buyzone_radius_override.IntValue > -1 ? tfgo_buyzone_radius_override.FloatValue : g_dynamicBuyzoneRadius[team];
-		if (distance <= radius) // Player is in buy zone
+		if (distance <= radius && !g_playerInDynamicBuyZone[client]) // Player has entered buy zone
 		{
-			if (player.ActiveBuyMenu == null && !g_playerExitedBuyMenu[client])
+			g_playerInDynamicBuyZone[client] = !g_playerInDynamicBuyZone[client];
+			if (player.ActiveBuyMenu == null)
 				DisplaySlotSelectionMenu(client);
 		}
-		else // Player has left buy zone
+		else if (distance > radius && g_playerInDynamicBuyZone[client]) // Player has left buy zone
 		{
+			g_playerInDynamicBuyZone[client] = !g_playerInDynamicBuyZone[client];
 			if (player.ActiveBuyMenu != null)
 			{
 				player.ActiveBuyMenu.Cancel();


### PR DESCRIPTION
Aims to make the calculated buy zone more like the ``func_respawnroom`` buy zone by simulating ``StartTouch`` and ``EndTouch``.
This would also allow closing the buy menu (#24) without being locked out of it for the rest of the round.