### PR TITLE
Add team scrambling and half-time switch

### DIFF
--- a/addons/sourcemod/gamedata/tfgo.txt
+++ b/addons/sourcemod/gamedata/tfgo.txt
@@ -70,6 +70,16 @@
 				"windows"	"160"
 				"linux"		"161"
 			}
+			"CTeamplayRules::SetSwitchTeams"
+			{
+				"windows"	"162"
+				"linux"		"163"
+			}
+			"CTeamplayRules::SetScrambleTeams"
+			{
+				"windows"	"165"
+				"linux"		"166"
+			}
 		}
 		"Addresses"
 		{

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -53,11 +53,13 @@ float g_BombPlantedTime;
 TFTeam g_BombPlantingTeam;
 bool g_HasPlayerSuicided[TF_MAXPLAYERS + 1];
 bool g_IsPlayerInDynamicBuyZone[TF_MAXPLAYERS + 1];
+int g_RoundsPlayed;
 
 // ConVars
 ConVar tfgo_buytime;
 ConVar tfgo_buyzone_radius_override;
 ConVar tfgo_bomb_timer;
+ConVar tfgo_maxrounds;
 ConVar tfgo_startmoney;
 ConVar tfgo_maxmoney;
 ConVar tfgo_cash_player_bomb_planted;
@@ -154,6 +156,7 @@ public void OnPluginStart()
 	tfgo_buytime = CreateConVar("tfgo_buytime", "45", "How many seconds after spawning players can buy items for", _, true, tf_arena_preround_time.FloatValue);
 	tfgo_buyzone_radius_override = CreateConVar("tfgo_buyzone_radius_override", "-1", "Overrides the default calculated buyzone radius on maps with no respawn room");
 	tfgo_bomb_timer = CreateConVar("tfgo_bomb_timer", "45", "How long from when the bomb is planted until it blows", _, true, 15.0, true, tf_arena_round_time.FloatValue);
+	tfgo_maxrounds = CreateConVar("tfgo_maxrounds", "15", "Maximum number of rounds to play before a team scramble occurs");
 	tfgo_startmoney = CreateConVar("tfgo_startmoney", "1000", "Amount of money each player gets when they reset");
 	tfgo_maxmoney = CreateConVar("tfgo_maxmoney", "10000", "Maximum amount of money allowed in a player's account", _, true, tfgo_startmoney.FloatValue);
 	tfgo_cash_player_bomb_planted = CreateConVar("tfgo_cash_player_bomb_planted", "200", "Cash award for each player that planted the bomb");
@@ -807,6 +810,18 @@ public Action Event_Arena_Win_Panel(Event event, const char[] name, bool dontBro
 	// Adjust team losing streaks
 	losingTeam.LoseStreak++;
 	winningTeam.LoseStreak--;
+	
+	g_RoundsPlayed++;
+	if (g_RoundsPlayed == RoundFloat(tfgo_maxrounds.IntValue / 2.0))
+	{
+		ServerCommand("mp_switchteams");
+	}
+	else if (g_RoundsPlayed == tfgo_maxrounds.IntValue)
+	{
+		ServerCommand("mp_scrambleteams");
+		PlayTeamScrambleAlert();
+		g_RoundsPlayed = 0;
+	}
 	
 	// Reset timers
 	g_TenSecondRoundTimer = null;

--- a/addons/sourcemod/scripting/tfgo/sound.sp
+++ b/addons/sourcemod/scripting/tfgo/sound.sp
@@ -3,6 +3,12 @@ static char g_BombPlantedAnnouncerAlerts[][PLATFORM_MAX_PATH] =  {
 	"vo/mvm_bomb_alerts02.mp3"
 };
 
+static char g_TeamScrambleAlerts[][PLATFORM_MAX_PATH] =  {
+	"vo/announcer_am_teamscramble01.mp3", 
+	"vo/announcer_am_teamscramble02.mp3", 
+	"vo/announcer_am_teamscramble03.mp3"
+};
+
 static char g_BombPlantedEngineerAlerts[][PLATFORM_MAX_PATH] =  {
 	"vo/engineer_mvm_bomb_see01.mp3", 
 	"vo/engineer_mvm_bomb_see02.mp3", 
@@ -33,6 +39,7 @@ public void PrecacheSounds()
 	PrecacheSound(BOMB_BEEPING_SOUND);
 	
 	for (int i = 0; i < sizeof(g_BombPlantedAnnouncerAlerts); i++)PrecacheSound(g_BombPlantedAnnouncerAlerts[i]);
+	for (int i = 0; i < sizeof(g_TeamScrambleAlerts); i++)PrecacheSound(g_TeamScrambleAlerts[i]);
 	for (int i = 0; i < sizeof(g_BombPlantedEngineerAlerts); i++)PrecacheSound(g_BombPlantedEngineerAlerts[i]);
 	for (int i = 0; i < sizeof(g_BombPlantedHeavyAlerts); i++)PrecacheSound(g_BombPlantedHeavyAlerts[i]);
 	for (int i = 0; i < sizeof(g_BombPlantedMedicAlerts); i++)PrecacheSound(g_BombPlantedMedicAlerts[i]);
@@ -42,6 +49,11 @@ public void PrecacheSounds()
 public void PlayAnnouncerBombAlert()
 {
 	EmitSoundToAll(g_BombPlantedAnnouncerAlerts[GetRandomInt(0, sizeof(g_BombPlantedAnnouncerAlerts) - 1)], _, SNDCHAN_VOICE_BASE); // SNDCHAN_VOICE_BASE = CHAN_VOICE2
+}
+
+public void PlayTeamScrambleAlert()
+{
+	EmitSoundToAll(g_TeamScrambleAlerts[GetRandomInt(0, sizeof(g_TeamScrambleAlerts) - 1)], _, SNDCHAN_VOICE_BASE);
 }
 
 public void ShoutBombWarnings()


### PR DESCRIPTION
Related to #25 

Because team scrambling in arena mode doesn't work when ``tf_arena_use_queue`` is set to ``1``, we need to roll our own.

TF:GO scramble will not rely on maximum wins but rather total rounds played, controlled by the ``tfgo_maxrounds`` cvar. This will also swap the teams when half of the rounds have been played, just like half-time in CS:GO.