### PR TITLE
Fix weapon switch to Thermal Thruster

### DIFF
--- a/addons/sourcemod/scripting/tfgo/stocks.sp
+++ b/addons/sourcemod/scripting/tfgo/stocks.sp
@@ -181,14 +181,10 @@ stock void TF2_EquipWeapon(int client, int weapon, char[] className = NULL_STRIN
 				SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", melee);
 			}
 		}
-		else if (StrEqual(className, "tf_weapon_invis") || StrEqual(className, "tf_weapon_rocketpack"))
-		{
-			// These weapons like to glitch out when switched to
-			return;
-		}
 		else
 		{
-			SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", weapon);
+			// Switch current active weapon
+			FakeClientCommand(client, "use %s", className);
 		}
 	}
 }


### PR DESCRIPTION
Attempting to set entprop `m_hActiveWeapon` to Thermal Thruster doesn't do weapon anim properly.

Instead, call command to client `use classname` to force weapon switch, and does weapon animation. Invis watch check also removed as attempting `use` on invis watch does nothing, and still works fine.