### PR TITLE
Adjust weapon prices

### DIFF
--- a/addons/sourcemod/configs/tfgo/tfgo.cfg
+++ b/addons/sourcemod/configs/tfgo/tfgo.cfg
@@ -58,7 +58,7 @@
 		// Scout - Melee
 		"44" // Sandman
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		"317" // Candy Cane
 		{
@@ -82,7 +82,7 @@
 		}
 		"648" // Wrap Assassin
 		{
-			"cost" "900"
+			"cost" "800"
 		}
 		
 		// Soldier - Primary
@@ -214,7 +214,7 @@
 		// Pyro - Melee
 		"38" // Axtinguisher
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		"153" // Homewrecker
 		{
@@ -222,11 +222,11 @@
 		}
 		"214" // Powerjack
 		{
-			"cost" "900"
+			"cost" "800"
 		}
 		"326" // Back Scratcher
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		"348" // Sharpened Volcano Fragment 
 		{
@@ -238,7 +238,7 @@
 		}
 		"813" // Neon Annihilator 
 		{
-			"cost" "700"
+			"cost" "600"
 		}
 		"1181" //  Hot Hand
 		{
@@ -296,11 +296,11 @@
 		// Demoman - Melee
 		"132" // Eyelander
 		{
-			"cost" "900"
+			"cost" "800"
 		}
 		"172" // Scotsman's Skullcutter 
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		"307" // Ullapool Caber
 		{
@@ -308,11 +308,11 @@
 		}
 		"327" // Claidheamh Mòr
 		{
-			"cost" "700"
+			"cost" "600"
 		}
 		"404" // Persian Persuader
 		{
-			"cost" "700"
+			"cost" "600"
 		}
 		
 		// Heavy - Primary

--- a/addons/sourcemod/configs/tfgo/tfgo.cfg
+++ b/addons/sourcemod/configs/tfgo/tfgo.cfg
@@ -6,59 +6,59 @@
 		// Scout - Primary
 		"13" // Scattergun
 		{
-			"cost" "3250"
+			"cost" "3300"
 		}
 		"45" // Force-A-Nature
 		{
-			"cost" "3100"
+			"cost" "3150"
 		}
 		"220" // Shortstop
 		{
-			"cost" "3000"
+			"cost" "3150"
 		}
 		"448" // Soda Popper
 		{
-			"cost" "3000"
+			"cost" "3150"
 		}
 		"772" // Baby Face's Blaster
 		{
-			"cost" "2750"
+			"cost" "2850"
 		}
 		"1103" // Back Scatter
 		{
-			"cost" "2500"
+			"cost" "2550"
 		}
 		
 		// Scout - Secondary
 		"46" // Bonk! Atomic Punch
 		{
-			"cost" "800"
+			"cost" "500"
 		}
 		"163" // Crit-a-Cola
 		{
-			"cost" "800"
+			"cost" "500"
 		}
 		"222" // Mad Milk
 		{
-			"cost" "1000"
+			"cost" "900"
 		}
 		"449" // Winger
 		{
-			"cost" "1250"
+			"cost" "700"
 		}
 		"773" // Pretty Boy's Pocket Pistol 
 		{
-			"cost" "1250"
+			"cost" "700"
 		}
 		"812" // The Flying Guillotine 
 		{
-			"cost" "600"
+			"cost" "500"
 		}
 		
 		// Scout - Melee
 		"44" // Sandman
 		{
-			"cost" "900"
+			"cost" "800"
 		}
 		"317" // Candy Cane
 		{
@@ -74,7 +74,7 @@
 		}
 		"355" // Fan O'War
 		{
-			"cost" "600"
+			"cost" "500"
 		}
 		"450" // Atomizer
 		{
@@ -82,7 +82,7 @@
 		}
 		"648" // Wrap Assassin
 		{
-			"cost" "950"
+			"cost" "900"
 		}
 		
 		// Soldier - Primary
@@ -92,19 +92,19 @@
 		}
 		"127" // Direct Hit
 		{
-			"cost" "4700"
+			"cost" "4600"
 		}
 		"228" // Black Box
 		{
-			"cost" "4700"
+			"cost" "4600"
 		}
 		"237" // Rocket Jumper
 		{
-			"cost" "750"
+			"cost" "700"
 		}
 		"414" // Liberty Launcher
 		{
-			"cost" "4100"
+			"cost" "4150"
 		}
 		"441" // Cow Mangler 5000
 		{
@@ -112,43 +112,43 @@
 		}
 		"730" // Beggar's Bazooka 
 		{
-			"cost" "4350"
+			"cost" "4300"
 		}
 		"1104" // Air Strike
 		{
-			"cost" "3900"
+			"cost" "3850"
 		}
 		
 		// Soldier - Secondary
 		"129" // Buff Banner
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		"226" // Battalion's Backup
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		"354" // Concheror
 		{
-			"cost" "1000"
+			"cost" "900"
 		}
 		"133" // Gunboats
 		{
-			"cost" "650"
+			"cost" "500"
 		}
 		"444" // Mantreads
 		{
-			"cost" "650"
+			"cost" "500"
 		}
 		"442" // Righteous Bison
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		
 		// Soldier - Melee
 		"128" // Equalizer
 		{
-			"cost" "900"
+			"cost" "600"
 		}
 		"416" // Market Gardener
 		{
@@ -156,17 +156,17 @@
 		}
 		"447" // Disciplinary Action 
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		"775" // Escape Plan 
 		{
-			"cost" "900"
+			"cost" "800"
 		}
 		
 		// Pyro - Primary
 		"21" // Flame thrower
 		{
-			"cost" "4350"
+			"cost" "4300"
 		}
 		"40" // Backburner
 		{
@@ -178,37 +178,37 @@
 		}
 		"594" // Phlogistinator
 		{
-			"cost" "4300"
+			"cost" "4150"
 		}
 		"1178" // Dragon's Fury
 		{
-			"cost" "3950"
+			"cost" "4000"
 		}
 		
 		// Pyro - Secondary
 		"39" // Flare Gun
 		{
-			"cost" "1150"
+			"cost" "900"
 		}
 		"351" // Detonator
 		{
-			"cost" "1150"
+			"cost" "900"
 		}
 		"595" // Manmelter
 		{
-			"cost" "1150"
+			"cost" "900"
 		}
 		"740" // Scorch Shot
 		{
-			"cost" "1150"
+			"cost" "900"
 		}
 		"1179" // Thermal Thruster
 		{
-			"cost" "650"
+			"cost" "700"
 		}
 		"1180" // Gas Passer
 		{
-			"cost" "400"
+			"cost" "300"
 		}
 		
 		// Pyro - Melee
@@ -218,19 +218,19 @@
 		}
 		"153" // Homewrecker
 		{
-			"cost" "600"
+			"cost" "700"
 		}
 		"214" // Powerjack
 		{
-			"cost" "1150"
+			"cost" "900"
 		}
 		"326" // Back Scratcher
 		{
-			"cost" "1000"
+			"cost" "800"
 		}
 		"348" // Sharpened Volcano Fragment 
 		{
-			"cost" "550"
+			"cost" "500"
 		}
 		"593" // Third Degree
 		{
@@ -238,11 +238,11 @@
 		}
 		"813" // Neon Annihilator 
 		{
-			"cost" "600"
+			"cost" "700"
 		}
 		"1181" //  Hot Hand
 		{
-			"cost" "550"
+			"cost" "600"
 		}
 		
 		// Demoman - Primary

--- a/addons/sourcemod/configs/tfgo/tfgo.cfg
+++ b/addons/sourcemod/configs/tfgo/tfgo.cfg
@@ -166,23 +166,23 @@
 		// Pyro - Primary
 		"21" // Flame thrower
 		{
-			"cost" "4300"
+			"cost" "4250"
 		}
 		"40" // Backburner
 		{
-			"cost" "4150"
+			"cost" "4100"
 		}
 		"215" // Degreaser
 		{
-			"cost" "4000"
+			"cost" "3950"
 		}
 		"594" // Phlogistinator
 		{
-			"cost" "4150"
+			"cost" "4100"
 		}
 		"1178" // Dragon's Fury
 		{
-			"cost" "4000"
+			"cost" "3950"
 		}
 		
 		// Pyro - Secondary
@@ -248,15 +248,15 @@
 		// Demoman - Primary
 		"19" // Grenade Launcher
 		{
-			"cost" "2350"
+			"cost" "2250"
 		}
 		"308" // Loch-n-Load
 		{
-			"cost" "2300"
+			"cost" "2250"
 		}
 		"996" // Loose Cannon
 		{
-			"cost" "2450"
+			"cost" "2250"
 		}
 		"1151" // Iron Bomber
 		{
@@ -274,29 +274,29 @@
 		}
 		"130" // Scottish Resistance 
 		{
-			"cost" "4200"
+			"cost" "4100"
 		}
 		"1150" // Quickiebomb Launcher 
 		{
-			"cost" "3850"
+			"cost" "3800"
 		}
 		"265" // Sticky Jumper 
 		{
-			"cost" "650"
+			"cost" "500"
 		}
 		"406" // Splendid Screen 
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		"1099" // Tide Turner 
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		
 		// Demoman - Melee
 		"132" // Eyelander
 		{
-			"cost" "1000"
+			"cost" "900"
 		}
 		"172" // Scotsman's Skullcutter 
 		{
@@ -304,7 +304,7 @@
 		}
 		"307" // Ullapool Caber
 		{
-			"cost" "650"
+			"cost" "500"
 		}
 		"327" // Claidheamh Mòr
 		{
@@ -318,15 +318,15 @@
 		// Heavy - Primary
 		"15" // Minigun
 		{
-			"cost" "4650"
+			"cost" "4750"
 		}
 		"41" // Natascha
 		{
-			"cost" "4400"
+			"cost" "4450"
 		}
 		"312" // Brass Beast
 		{
-			"cost" "4400"
+			"cost" "4450"
 		}
 		"424" // Tomislav
 		{
@@ -334,35 +334,35 @@
 		}
 		"811" // Huo-Long Heater
 		{
-			"cost" "4050"
+			"cost" "4000"
 		}
 		
 		// Heavy - Secondary
 		"42" // Sandvich
 		{
-			"cost" "1150"
+			"cost" "900"
 		}
 		"159" // Dalokohs Bar
 		{
-			"cost" "700"
+			"cost" "500"
 		}
 		"311" // Buffalo Steak Sandvich
 		{
-			"cost" "700"
+			"cost" "500"
 		}
 		"1190" // Second Banana
 		{
-			"cost" "900"
+			"cost" "700"
 		}
 		"425" // Family Business 
 		{
-			"cost" "1100"
+			"cost" "700"
 		}
 		
 		// Heavy - Melee
 		"43" // Killing Gloves of Boxing 
 		{
-			"cost" "650"
+			"cost" "600"
 		}
 		"239" // Gloves of Running Urgently 
 		{
@@ -374,11 +374,11 @@
 		}
 		"331" // Fists of Steel 
 		{
-			"cost" "750"
+			"cost" "700"
 		}
 		"426" // Eviction Notice 
 		{
-			"cost" "600"
+			"cost" "500"
 		}
 		
 		// Engineer - Primary
@@ -388,67 +388,67 @@
 		}
 		"527" // Widowmaker
 		{
-			"cost" "1350"
+			"cost" "1250"
 		}
 		"588" // Pomson 6000
 		{
-			"cost" "750"
+			"cost" "700"
 		}
 		"997" // Rescue Ranger
 		{
-			"cost" "1350"
+			"cost" "1100"
 		}
 		
 		// Engineer - Secondary
 		"140" // Wrangler
 		{
-			"cost" "1350"
+			"cost" "900"
 		}
 		"528" // Short Circuit
 		{
-			"cost" "650"
+			"cost" "500"
 		}
 		
 		// Engineer - Melee
 		"142" // Gunslinger
 		{
-			"cost" "2650"
+			"cost" "2450"
 		}
 		"155" // Southern Hospitality
 		{
-			"cost" "800"
+			"cost" "650"
 		}
 		"329" // Jag
 		{
-			"cost" "2450"
+			"cost" "2300"
 		}
 		"589" // Eureka Effect 
 		{
-			"cost" "1200"
+			"cost" "650"
 		}
 		
 		// Engineer - PDA
 		"25" // Construction PDA
 		{
-			"cost" "2500"
+			"cost" "2400"
 		}
 		"26" // Destruction PDA
 		{
-			"cost" "250"
+			"cost" "200"
 		}
 		
 		// Medic - Primary
 		"36" // Blutsauger
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		"305" // Crusader's Crossbow
 		{
-			"cost" "2250"
+			"cost" "2150"
 		}
 		"412" // Overdose
 		{
-			"cost" "650"
+			"cost" "500"
 		}
 		
 		// Medic - Secondary
@@ -472,11 +472,11 @@
 		// Medic - Melee
 		"37" // Ubersaw
 		{
-			"cost" "1150"
+			"cost" "1100"
 		}
 		"173" // Vita-Saw 
 		{
-			"cost" "500"
+			"cost" "400"
 		}
 		"304" // Amputator
 		{
@@ -484,7 +484,7 @@
 		}
 		"413" // Solemn Vow 
 		{
-			"cost" "550"
+			"cost" "500"
 		}
 		
 		// Sniper - Primary
@@ -494,11 +494,11 @@
 		}
 		"230" // Sydney Sleeper
 		{
-			"cost" "3600"
+			"cost" "3450"
 		}
 		"402" // Bazaar Bargain 
 		{
-			"cost" "3350"
+			"cost" "3150"
 		}
 		"526" // Machina
 		{
@@ -506,21 +506,21 @@
 		}
 		"752" // Hitman's Heatmaker
 		{
-			"cost" "3350"
+			"cost" "3150"
 		}
 		"1098" // Classic
 		{
-			"cost" "3600"
+			"cost" "3300"
 		}
 		"56" // Huntsman
 		{
-			"cost" "3200"
+			"cost" "3300"
 		}
 		
 		// Sniper - Secondary
 		"58" // Jarate
 		{
-			"cost" "950"
+			"cost" "900"
 		}
 		"57" // Razorback
 		{
@@ -528,39 +528,39 @@
 		}
 		"231" // Darwin's Danger Shield
 		{
-			"cost" "650"
+			"cost" "700"
 		}
 		"642" // Cozy Camper 
 		{
-			"cost" "750"
+			"cost" "700"
 		}
 		"751" // Cleaner's Carbine
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		
 		// Sniper - Melee
 		"171" // Tribalman's Shiv 
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		"232" // Bushwacka
 		{
-			"cost" "650"
+			"cost" "500"
 		}
 		"401" // Shahanshah
 		{
-			"cost" "550"
+			"cost" "500"
 		}
 		
 		// Spy - Secondary
 		"24" // Revolver
 		{
-			"cost" "1700"
+			"cost" "1750"
 		}
 		"61" // Ambassador
 		{
-			"cost" "1800"
+			"cost" "1900"
 		}
 		"224" // L'Etranger
 		{
@@ -568,11 +568,11 @@
 		}
 		"460" // Enforcer
 		{
-			"cost" "1550"
+			"cost" "1600"
 		}
 		"525" // Diamondback
 		{
-			"cost" "1550"
+			"cost" "1600"
 		}
 		
 		// Spy - Building (Sapper)
@@ -584,19 +584,19 @@
 		// Spy - Melee
 		"225" // Your Eternal Reward
 		{
-			"cost" "2450"
+			"cost" "600"
 		}
 		"356" // Conniver's Kunai
 		{
-			"cost" "2450"
+			"cost" "600"
 		}
 		"461" // The Big Earner 
 		{
-			"cost" "2500"
+			"cost" "600"
 		}
 		"649" // The Spy-cicle
 		{
-			"cost" "2600"
+			"cost" "800"
 		}
 		
 		// Spy - PDA
@@ -608,31 +608,31 @@
 		// Spy - PDA2
 		"59" // Dead Ringer
 		{
-			"cost" "2850"
+			"cost" "1750"
 		}
 		"60" // Cloak and Dagger
 		{
-			"cost" "2450"
+			"cost" "1150"
 		}
 		
 		// Multi-Class - Secondary
 		"415" // Reserve Shooter (Soldier, Pyro)
 		{
-			"cost" "800"
+			"cost" "500"
 		}
 		"1153" // Panic Attack (Soldier, Pyro, Engineer, Heavy)
 		{
-			"cost" "800"
+			"cost" "700"
 		}
 		"1101" // B.A.S.E. Jumper (Soldier/Demoman)
 		{
-			"cost" "650"
+			"cost" "500"
 		}
 		
 		// Multi-Class - Melee
 		"357" // Half-Zaotichi (Soldier, Demoman)
 		{
-			"cost" "850"
+			"cost" "700"
 		}
 		"154" // Pain Train (Soldier, Demoman)
 		{

--- a/addons/sourcemod/configs/tfgo/tfgo.cfg
+++ b/addons/sourcemod/configs/tfgo/tfgo.cfg
@@ -474,10 +474,6 @@
 		{
 			"cost" "1100"
 		}
-		"173" // Vita-Saw 
-		{
-			"cost" "400"
-		}
 		"304" // Amputator
 		{
 			"cost" "600"


### PR DESCRIPTION
Weapon prices are a mess, most of them were chosen in very early development of the gamemode. This PR aims to streamline the prices, making secondaries a more worthwhile option. Should also make Spy somewhat viable (no more $2k+ knives).

Feel free to suggest changes while this is open.