### PR TITLE
Allow all weapons to headshot

### DIFF
--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -18,6 +18,8 @@
 
 #define TF_MAXPLAYERS 32
 
+#define HITGROUP_HEAD 1
+
 #define BOMB_MODEL "models/props_td/atom_bomb.mdl"
 #define BOMB_EXPLOSION_PARTICLE "mvm_hatch_destroy"
 #define BOMB_BEEPING_SOUND "player/cyoa_pda_beep3.wav"
@@ -247,7 +249,7 @@ public void OnClientConnected(int client)
 public void OnClientPutInServer(int client)
 {
 	SDKHook(client, SDKHook_PreThink, OnClientThink);
-	SDKHook(client, SDKHook_OnTakeDamage, OnClientTakeDamage);
+	SDKHook(client, SDKHook_TraceAttack, OnClientTraceAttack);
 }
 
 stock void ResetPlayer(int client, bool notify = true)
@@ -271,7 +273,7 @@ public void OnClientThink(int client)
 public void OnClientDisconnect(int client)
 {
 	SDKUnhook(client, SDKHook_PreThink, OnClientThink);
-	SDKUnhook(client, SDKHook_OnTakeDamage, OnClientTakeDamage);
+	SDKUnhook(client, SDKHook_TraceAttack, OnClientTraceAttack);
 	
 	// Force-end round if last client in team disconnects during active bomb
 	if (g_IsBombPlanted && IsValidClient(client))
@@ -282,17 +284,16 @@ public void OnClientDisconnect(int client)
 	}
 }
 
-public Action OnClientTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action OnClientTraceAttack(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &ammotype, int hitbox, int hitgroup)
 {
-	if (tfgo_all_weapons_can_headshot.BoolValue && weapon > -1)
+	if (tfgo_all_weapons_can_headshot.BoolValue && hitgroup == HITGROUP_HEAD)
 	{
-		damagetype |= DMG_USE_HITLOCATIONS;
+		// All headshots should deal critical damage
+		damagetype |= DMG_CRIT;
 		return Plugin_Changed;
 	}
-	else
-	{
-		return Plugin_Continue;
-	}
+	
+	return Plugin_Continue;
 }
 
 public void ChooseRandomMusicKit()

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -247,6 +247,7 @@ public void OnClientConnected(int client)
 public void OnClientPutInServer(int client)
 {
 	SDKHook(client, SDKHook_PreThink, OnClientThink);
+	SDKHook(client, SDKHook_OnTakeDamage, OnClientTakeDamage);
 }
 
 stock void ResetPlayer(int client, bool notify = true)
@@ -270,6 +271,7 @@ public void OnClientThink(int client)
 public void OnClientDisconnect(int client)
 {
 	SDKUnhook(client, SDKHook_PreThink, OnClientThink);
+	SDKUnhook(client, SDKHook_OnTakeDamage, OnClientTakeDamage);
 	
 	// Force-end round if last client in team disconnects during active bomb
 	if (g_IsBombPlanted && IsValidClient(client))
@@ -280,11 +282,11 @@ public void OnClientDisconnect(int client)
 	}
 }
 
-public Action OnTakeDamage(int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action OnClientTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 {
-	if (tfgo_all_weapons_can_headshot.BoolValue)
+	if (tfgo_all_weapons_can_headshot.BoolValue && weapon > -1)
 	{
-		damagetype &= DMG_USE_HITLOCATIONS;
+		damagetype |= DMG_USE_HITLOCATIONS;
 		return Plugin_Changed;
 	}
 	else

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -59,6 +59,7 @@ bool g_IsPlayerInDynamicBuyZone[TF_MAXPLAYERS + 1];
 int g_RoundsPlayed;
 
 // ConVars
+ConVar tfgo_all_weapons_can_headshot;
 ConVar tfgo_buytime;
 ConVar tfgo_buyzone_radius_override;
 ConVar tfgo_bomb_timer;
@@ -157,6 +158,7 @@ public void OnPluginStart()
 	mp_bonusroundtime = FindConVar("mp_bonusroundtime");
 	
 	// Create TFGO ConVars
+	tfgo_all_weapons_can_headshot = CreateConVar("tfgo_all_weapons_can_headshot", "0", "Whether all weapons should be able to headshot");
 	tfgo_buytime = CreateConVar("tfgo_buytime", "45", "How many seconds after spawning players can buy items for", _, true, tf_arena_preround_time.FloatValue);
 	tfgo_buyzone_radius_override = CreateConVar("tfgo_buyzone_radius_override", "-1", "Overrides the default calculated buyzone radius on maps with no respawn room");
 	tfgo_bomb_timer = CreateConVar("tfgo_bomb_timer", "45", "How long from when the bomb is planted until it blows", _, true, 15.0, true, tf_arena_round_time.FloatValue);
@@ -275,6 +277,19 @@ public void OnClientDisconnect(int client)
 		TFTeam team = TF2_GetClientTeam(client);
 		if (team > TFTeam_Spectator && g_BombPlantingTeam != team && GetAlivePlayerCountForTeam(team) <= 0)
 			g_IsBombPlanted = false;
+	}
+}
+
+public Action OnTakeDamage(int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+{
+	if (tfgo_all_weapons_can_headshot.BoolValue)
+	{
+		damagetype &= DMG_USE_HITLOCATIONS;
+		return Plugin_Changed;
+	}
+	else
+	{
+		return Plugin_Continue;
 	}
 }
 


### PR DESCRIPTION
This may be the worst thing I've added so far but it has been repeatedly requested so here it is.

Setting the convar ``tfgo_all_weapons_can_headshot`` to ``1`` will allow **all** bullet-based weapons to headshot.
May very easily break the entire gamemode, so it is disabled by default for now until further testing has been done.