### PR TITLE
Consecutive Losses

### DIFF
--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -30,6 +30,9 @@
 #define BOMB_EXPLOSION_DAMAGE 500.0
 #define BOMB_EXPLOSION_RADIUS 800.0
 
+#define MIN_CONSECUTIVE_LOSSES 0
+#define STARTING_CONSECUTIVE_LOSSES 1
+
 
 // Timers
 Handle g_BuyTimeTimer;
@@ -164,7 +167,7 @@ public void OnPluginStart()
 	// Create TFGO ConVars
 	tfgo_all_weapons_can_headshot = CreateConVar("tfgo_all_weapons_can_headshot", "0", "Whether all weapons should be able to headshot");
 	tfgo_buytime = CreateConVar("tfgo_buytime", "45", "How many seconds after spawning players can buy items for", _, true, tf_arena_preround_time.FloatValue);
-	tfgo_consecutive_loss_max = CreateConVar("tfgo_consecutive_loss_max", "4", "The maximum of consecutive losses for each team that will be kept track of", _, true, float(TFGO_STARTING_CONSECUTIVE_LOSSES));
+	tfgo_consecutive_loss_max = CreateConVar("tfgo_consecutive_loss_max", "4", "The maximum of consecutive losses for each team that will be kept track of", _, true, float(STARTING_CONSECUTIVE_LOSSES));
 	tfgo_buyzone_radius_override = CreateConVar("tfgo_buyzone_radius_override", "-1", "Overrides the default calculated buyzone radius on maps with no respawn room");
 	tfgo_bomb_timer = CreateConVar("tfgo_bomb_timer", "45", "How long from when the bomb is planted until it blows", _, true, 15.0, true, tf_arena_round_time.FloatValue);
 	tfgo_maxrounds = CreateConVar("tfgo_maxrounds", "15", "Maximum number of rounds to play before a team scramble occurs");

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -63,6 +63,7 @@ int g_RoundsPlayed;
 // ConVars
 ConVar tfgo_all_weapons_can_headshot;
 ConVar tfgo_buytime;
+ConVar tfgo_consecutive_loss_max;
 ConVar tfgo_buyzone_radius_override;
 ConVar tfgo_bomb_timer;
 ConVar tfgo_maxrounds;
@@ -163,6 +164,7 @@ public void OnPluginStart()
 	// Create TFGO ConVars
 	tfgo_all_weapons_can_headshot = CreateConVar("tfgo_all_weapons_can_headshot", "0", "Whether all weapons should be able to headshot");
 	tfgo_buytime = CreateConVar("tfgo_buytime", "45", "How many seconds after spawning players can buy items for", _, true, tf_arena_preround_time.FloatValue);
+	tfgo_consecutive_loss_max = CreateConVar("tfgo_consecutive_loss_max", "4", "The maximum of consecutive losses for each team that will be kept track of", _, true, float(TFGO_STARTING_CONSECUTIVE_LOSSES));
 	tfgo_buyzone_radius_override = CreateConVar("tfgo_buyzone_radius_override", "-1", "Overrides the default calculated buyzone radius on maps with no respawn room");
 	tfgo_bomb_timer = CreateConVar("tfgo_bomb_timer", "45", "How long from when the bomb is planted until it blows", _, true, 15.0, true, tf_arena_round_time.FloatValue);
 	tfgo_maxrounds = CreateConVar("tfgo_maxrounds", "15", "Maximum number of rounds to play before a team scramble occurs");
@@ -379,8 +381,8 @@ public MRESReturn Hook_SetWinningTeam(Handle params)
 		TFGOTeam blue = TFGOTeam(TFTeam_Blue);
 		red.AddToClientBalances(0, "%T", "Team_Cash_Award_no_income", LANG_SERVER);
 		blue.AddToClientBalances(0, "%T", "Team_Cash_Award_no_income", LANG_SERVER);
-		red.LoseStreak++;
-		blue.LoseStreak++;
+		red.ConsecutiveLosses++;
+		blue.ConsecutiveLosses++;
 		return MRES_Ignored;
 	}
 	
@@ -406,7 +408,7 @@ public MRESReturn Hook_HandleSwitchTeams()
 		ResetPlayer(client);
 	
 	for (int team = view_as<int>(TFTeam_Red); team <= view_as<int>(TFTeam_Blue); team++)
-		TFGOTeam(view_as<TFTeam>(team)).ResetLoseStreak();
+		TFGOTeam(view_as<TFTeam>(team)).ResetConsecutiveLosses();
 }
 
 public MRESReturn Hook_HandleScrambleTeams()
@@ -416,7 +418,7 @@ public MRESReturn Hook_HandleScrambleTeams()
 	
 	for (int team = view_as<int>(TFTeam_Red); team <= view_as<int>(TFTeam_Blue); team++)
 	{
-		TFGOTeam(view_as<TFTeam>(team)).ResetLoseStreak();
+		TFGOTeam(view_as<TFTeam>(team)).ResetConsecutiveLosses();
 		SetTeamScore(team, 0);
 	}
 	
@@ -873,9 +875,9 @@ public Action Event_Arena_Win_Panel(Event event, const char[] name, bool dontBro
 		}
 	}
 	
-	// Adjust team losing streaks
-	losingTeam.LoseStreak++;
-	winningTeam.LoseStreak--;
+	// Adjust consecutive loss count for each team
+	losingTeam.ConsecutiveLosses++;
+	winningTeam.ConsecutiveLosses--;
 	
 	g_RoundsPlayed++;
 	if (tfgo_halftime.BoolValue && g_RoundsPlayed == RoundFloat(tfgo_maxrounds.IntValue / 2.0))

--- a/addons/sourcemod/scripting/tfgo/methodmaps.sp
+++ b/addons/sourcemod/scripting/tfgo/methodmaps.sp
@@ -1,6 +1,3 @@
-#define TFGO_MIN_CONSECUTIVE_LOSSES		0
-#define TFGO_STARTING_CONSECUTIVE_LOSSES	1
-
 // -1 indicates the class should start with no weapon in that slot
 int g_DefaultWeaponIndexes[][] =  {
 	{ -1, -1, -1, -1, -1, -1 },  // Unknown
@@ -19,7 +16,7 @@ int g_PlayerLoadoutWeaponIndexes[TF_MAXPLAYERS + 1][view_as<int>(TFClass_Enginee
 int g_PlayerBalances[TF_MAXPLAYERS + 1];
 Menu g_ActiveBuyMenus[TF_MAXPLAYERS + 1];
 
-int g_TeamConsecutiveLosses[view_as<int>(TFTeam_Blue) + 1] =  { TFGO_STARTING_CONSECUTIVE_LOSSES, ... };
+int g_TeamConsecutiveLosses[view_as<int>(TFTeam_Blue) + 1] =  { STARTING_CONSECUTIVE_LOSSES, ... };
 
 
 methodmap TFGOPlayer
@@ -186,8 +183,8 @@ methodmap TFGOTeam
 		{
 			if (val > tfgo_consecutive_loss_max.IntValue)
 				g_TeamConsecutiveLosses[this] = tfgo_consecutive_loss_max.IntValue;
-			else if (val < TFGO_MIN_CONSECUTIVE_LOSSES)
-				g_TeamConsecutiveLosses[this] = TFGO_MIN_CONSECUTIVE_LOSSES;
+			else if (val < MIN_CONSECUTIVE_LOSSES)
+				g_TeamConsecutiveLosses[this] = MIN_CONSECUTIVE_LOSSES;
 			else
 				g_TeamConsecutiveLosses[this] = val;
 		}
@@ -203,7 +200,7 @@ methodmap TFGOTeam
 	
 	public void ResetConsecutiveLosses()
 	{
-		g_TeamConsecutiveLosses[this] = TFGO_STARTING_CONSECUTIVE_LOSSES;
+		g_TeamConsecutiveLosses[this] = STARTING_CONSECUTIVE_LOSSES;
 	}
 	
 	public void AddToClientBalances(int val, const char[] reason, any...)

--- a/addons/sourcemod/scripting/tfgo/methodmaps.sp
+++ b/addons/sourcemod/scripting/tfgo/methodmaps.sp
@@ -1,6 +1,5 @@
-#define TFGO_MIN_LOSESTREAK				0
-#define TFGO_MAX_LOSESTREAK				4
-#define TFGO_STARTING_LOSESTREAK		1
+#define TFGO_MIN_CONSECUTIVE_LOSSES		0
+#define TFGO_STARTING_CONSECUTIVE_LOSSES	1
 
 // -1 indicates the class should start with no weapon in that slot
 int g_DefaultWeaponIndexes[][] =  {
@@ -20,7 +19,7 @@ int g_PlayerLoadoutWeaponIndexes[TF_MAXPLAYERS + 1][view_as<int>(TFClass_Enginee
 int g_PlayerBalances[TF_MAXPLAYERS + 1];
 Menu g_ActiveBuyMenus[TF_MAXPLAYERS + 1];
 
-int g_TeamLosingStreaks[view_as<int>(TFTeam_Blue) + 1] =  { TFGO_STARTING_LOSESTREAK, ... };
+int g_TeamConsecutiveLosses[view_as<int>(TFTeam_Blue) + 1] =  { TFGO_STARTING_CONSECUTIVE_LOSSES, ... };
 
 
 methodmap TFGOPlayer
@@ -176,21 +175,21 @@ methodmap TFGOTeam
 		}
 	}
 	
-	property int LoseStreak
+	property int ConsecutiveLosses
 	{
 		public get()
 		{
-			return g_TeamLosingStreaks[this];
+			return g_TeamConsecutiveLosses[this];
 		}
 		
 		public set(int val)
 		{
-			if (val > TFGO_MAX_LOSESTREAK)
-				g_TeamLosingStreaks[this] = TFGO_MAX_LOSESTREAK;
-			else if (val < TFGO_MIN_LOSESTREAK)
-				g_TeamLosingStreaks[this] = TFGO_MIN_LOSESTREAK;
+			if (val > tfgo_consecutive_loss_max.IntValue)
+				g_TeamConsecutiveLosses[this] = tfgo_consecutive_loss_max.IntValue;
+			else if (val < TFGO_MIN_CONSECUTIVE_LOSSES)
+				g_TeamConsecutiveLosses[this] = TFGO_MIN_CONSECUTIVE_LOSSES;
 			else
-				g_TeamLosingStreaks[this] = val;
+				g_TeamConsecutiveLosses[this] = val;
 		}
 	}
 	
@@ -198,13 +197,13 @@ methodmap TFGOTeam
 	{
 		public get()
 		{
-			return tfgo_cash_team_loser_bonus.IntValue + tfgo_cash_team_loser_bonus_consecutive_rounds.IntValue * this.LoseStreak;
+			return tfgo_cash_team_loser_bonus.IntValue + tfgo_cash_team_loser_bonus_consecutive_rounds.IntValue * this.ConsecutiveLosses;
 		}
 	}
 	
-	public void ResetLoseStreak()
+	public void ResetConsecutiveLosses()
 	{
-		g_TeamLosingStreaks[this] = TFGO_STARTING_LOSESTREAK;
+		g_TeamConsecutiveLosses[this] = TFGO_STARTING_CONSECUTIVE_LOSSES;
 	}
 	
 	public void AddToClientBalances(int val, const char[] reason, any...)


### PR DESCRIPTION
Not a big PR; changes all mentions of "Lose Streak" or "Losing Streak" to "Consecutive Losses" to give this feature some semantic meaning.
Also adds a new convar ``tfgo_consecutive_loss_max`` to avoid hardcoding this value (minimum of ``0`` and starting value of ``1`` are still hardcoded because those are likely to never change).