### PR TITLE
Fix error from invalid slot in GiveNamedItem

### DIFF
--- a/addons/sourcemod/scripting/tfgo/sdk.sp
+++ b/addons/sourcemod/scripting/tfgo/sdk.sp
@@ -270,7 +270,7 @@ public MRESReturn Hook_GiveNamedItem(int client, Handle returnVal, Handle params
 	int slot = TF2_GetSlotInItem(defIndex, TF2_GetPlayerClass(client));
 	TFClassType class = TF2_GetPlayerClass(client);
 	
-	if (slot <= WeaponSlot_BuilderEngie && TFGOPlayer(client).GetWeaponFromLoadout(class, slot) != defIndex)
+	if (0 <= slot <= WeaponSlot_BuilderEngie && TFGOPlayer(client).GetWeaponFromLoadout(class, slot) != defIndex)
 	{
 		DHookSetReturn(returnVal, 0);
 		return MRES_Supercede;


### PR DESCRIPTION
Apparently it possible to get invalid slot (-1) when `GiveNamedItem` is called for class who usually shouldn't have said weapon index. How? I dunno