### PR TITLE
Use TF2 soundscripts

### DIFF
--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -18,11 +18,16 @@
 
 #define TF_MAXPLAYERS 32
 
-#define BOMB_MODEL "models/props_td/atom_bomb.mdl"
-#define BOMB_EXPLOSION_PARTICLE "mvm_hatch_destroy"
-#define BOMB_BEEPING_SOUND "player/cyoa_pda_beep3.wav"
-#define BOMB_WARNING_SOUND "mvm/mvm_bomb_warning.wav"
-#define BOMB_EXPLOSION_SOUND "mvm/mvm_bomb_explode.wav"
+#define MODEL_BOMB "models/props_td/atom_bomb.mdl"
+
+#define PARTICLE_BOMB_EXPLOSION "mvm_hatch_destroy"
+
+#define SOUND_BOMB_BEEPING "player/cyoa_pda_beep3.wav"
+#define GAMESOUND_BOMB_EXPLOSION "MVM.BombExplodes"
+#define GAMESOUND_BOMB_WARNING "MVM.BombWarning"
+#define GAMESOUND_PLAYER_PURCHASE "MVM.PlayerUpgraded"
+#define GAMESOUND_ANNOUNCER_BOMB_PLANTED "Announcer.MVM_Bomb_Alert_Entered"
+#define GAMESOUND_ANNOUNCER_TEAM_SCRAMBLE "Announcer.AM_TeamScrambleRandom"
 
 #define BOMB_EXPLOSION_DAMAGE 500.0
 #define BOMB_EXPLOSION_RADIUS 800.0
@@ -33,6 +38,7 @@
 #define HELMET_PRICE 350
 #define KEVLAR_PRICE 650
 #define ASSAULTSUIT_PRICE 1000
+
 
 const TFTeam TFTeam_CT = TFTeam_Red;
 const TFTeam TFTeam_T = TFTeam_Blue;
@@ -746,7 +752,7 @@ void PlantBomb(TFTeam team, int cp, ArrayList cappers)
 	GetEntPropVector(capper, Prop_Send, "m_angRotation", angles);
 	
 	int bomb = CreateEntityByName("prop_dynamic_override");
-	SetEntityModel(bomb, BOMB_MODEL);
+	SetEntityModel(bomb, MODEL_BOMB);
 	DispatchSpawn(bomb);
 	TeleportEntity(bomb, origin, angles, NULL_VECTOR);
 	
@@ -760,8 +766,8 @@ void PlantBomb(TFTeam team, int cp, ArrayList cappers)
 	g_CurrentMusicKit.StopMusicForAll(Music_StartAction);
 	g_CurrentMusicKit.StopMusicForAll(Music_RoundTenSecCount);
 	g_CurrentMusicKit.PlayMusicToAll(Music_BombPlanted);
-	PlayAnnouncerBombAlert();
-	ShoutBombWarnings();
+	EmitGameSoundToAll(GAMESOUND_ANNOUNCER_BOMB_PLANTED);
+	EmitBombSeeGameSounds();
 	
 	// Reset timers
 	g_TenSecondRoundTimer = null;
@@ -781,7 +787,7 @@ public Action Timer_PlayBombBeeping(Handle timer, int bomb)
 	
 	float origin[3];
 	GetEntPropVector(bomb, Prop_Send, "m_vecOrigin", origin);
-	EmitAmbientSound(BOMB_BEEPING_SOUND, origin, bomb);
+	EmitAmbientSound(SOUND_BOMB_BEEPING, origin, bomb);
 	return Plugin_Continue;
 }
 
@@ -806,7 +812,7 @@ public Action Timer_PlayBombExplosionWarning(Handle timer, int bomb)
 	
 	float origin[3];
 	GetEntPropVector(bomb, Prop_Send, "m_vecOrigin", origin);
-	EmitAmbientSound(BOMB_WARNING_SOUND, origin, bomb, SNDLEVEL_RAIDSIREN);
+	EmitAmbientGameSound(GAMESOUND_BOMB_WARNING, origin, bomb);
 }
 
 public Action Timer_DetonateBomb(Handle timer, int bombRef)
@@ -822,7 +828,7 @@ public Action Timer_DetonateBomb(Handle timer, int bombRef)
 	int bomb = EntRefToEntIndex(bombRef);
 	float origin[3];
 	GetEntPropVector(bomb, Prop_Send, "m_vecOrigin", origin);
-	TF2_Explode(_, origin, BOMB_EXPLOSION_DAMAGE, BOMB_EXPLOSION_RADIUS, BOMB_EXPLOSION_PARTICLE, BOMB_EXPLOSION_SOUND);
+	TF2_Explode(_, origin, BOMB_EXPLOSION_DAMAGE, BOMB_EXPLOSION_RADIUS, PARTICLE_BOMB_EXPLOSION, GAMESOUND_BOMB_EXPLOSION);
 	RemoveEntity(bomb);
 	
 	Forward_BombDetonated(g_BombPlantingTeam);
@@ -945,12 +951,12 @@ public Action CommandListener_Destroy(int client, const char[] command, int args
 
 void PrecacheModels()
 {
-	PrecacheModel(BOMB_MODEL);
+	PrecacheModel(MODEL_BOMB);
 }
 
 void PrecacheParticleSystems()
 {
-	PrecacheParticleSystem(BOMB_EXPLOSION_PARTICLE);
+	PrecacheParticleSystem(PARTICLE_BOMB_EXPLOSION);
 }
 
 void Toggle_ConVars(bool toggle)

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -26,7 +26,7 @@
 #define GAMESOUND_BOMB_EXPLOSION "MVM.BombExplodes"
 #define GAMESOUND_BOMB_WARNING "MVM.BombWarning"
 #define GAMESOUND_PLAYER_PURCHASE "MVM.PlayerUpgraded"
-#define GAMESOUND_ANNOUNCER_BOMB_PLANTED "Announcer.MVM_Bomb_Alert_Entered"
+#define GAMESOUND_ANNOUNCER_BOMB_PLANTED "Announcer.SecurityAlert"
 #define GAMESOUND_ANNOUNCER_TEAM_SCRAMBLE "Announcer.AM_TeamScrambleRandom"
 
 #define BOMB_EXPLOSION_DAMAGE 500.0
@@ -812,7 +812,7 @@ public Action Timer_PlayBombExplosionWarning(Handle timer, int bomb)
 	
 	float origin[3];
 	GetEntPropVector(bomb, Prop_Send, "m_vecOrigin", origin);
-	EmitAmbientGameSound(GAMESOUND_BOMB_WARNING, origin, bomb);
+	EmitGameSoundToAll(GAMESOUND_BOMB_WARNING, bomb);
 }
 
 public Action Timer_DetonateBomb(Handle timer, int bombRef)
@@ -828,7 +828,8 @@ public Action Timer_DetonateBomb(Handle timer, int bombRef)
 	int bomb = EntRefToEntIndex(bombRef);
 	float origin[3];
 	GetEntPropVector(bomb, Prop_Send, "m_vecOrigin", origin);
-	TF2_Explode(_, origin, BOMB_EXPLOSION_DAMAGE, BOMB_EXPLOSION_RADIUS, PARTICLE_BOMB_EXPLOSION, GAMESOUND_BOMB_EXPLOSION);
+	TF2_Explode(_, origin, BOMB_EXPLOSION_DAMAGE, BOMB_EXPLOSION_RADIUS, PARTICLE_BOMB_EXPLOSION);
+	EmitGameSoundToAll(GAMESOUND_BOMB_EXPLOSION, bomb);
 	RemoveEntity(bomb);
 	
 	Forward_BombDetonated(g_BombPlantingTeam);

--- a/addons/sourcemod/scripting/tfgo/buymenu.sp
+++ b/addons/sourcemod/scripting/tfgo/buymenu.sp
@@ -146,7 +146,7 @@ public int MenuHandler_WeaponBuyMenu(Menu menu, MenuAction action, int param1, i
 			
 			if (TFGOPlayer(param1).AttemptToBuyWeapon(StringToInt(info)) == BUY_BOUGHT)
 			{
-				EmitPurchaseGameSound(param1);
+				EmitGameSoundToAll(GAMESOUND_PLAYER_PURCHASE, param1);
 				DisplayMainBuyMenu(param1);
 			}
 		}
@@ -241,7 +241,7 @@ public int MenuHandler_EquipmentBuyMenu(Menu menu, MenuAction action, int param1
 			
 			if (result == BUY_BOUGHT)
 			{
-				EmitPurchaseGameSound(param1);
+				EmitGameSoundToAll(GAMESOUND_PLAYER_PURCHASE, param1);
 				DisplayMainBuyMenu(param1);
 			}
 		}

--- a/addons/sourcemod/scripting/tfgo/buymenu.sp
+++ b/addons/sourcemod/scripting/tfgo/buymenu.sp
@@ -146,7 +146,7 @@ public int MenuHandler_WeaponBuyMenu(Menu menu, MenuAction action, int param1, i
 			
 			if (TFGOPlayer(param1).AttemptToBuyWeapon(StringToInt(info)) == BUY_BOUGHT)
 			{
-				PlayPurchaseSound(param1);
+				EmitPurchaseGameSound(param1);
 				DisplayMainBuyMenu(param1);
 			}
 		}
@@ -241,7 +241,7 @@ public int MenuHandler_EquipmentBuyMenu(Menu menu, MenuAction action, int param1
 			
 			if (result == BUY_BOUGHT)
 			{
-				PlayPurchaseSound(param1);
+				EmitPurchaseGameSound(param1);
 				DisplayMainBuyMenu(param1);
 			}
 		}

--- a/addons/sourcemod/scripting/tfgo/sdk.sp
+++ b/addons/sourcemod/scripting/tfgo/sdk.sp
@@ -258,7 +258,7 @@ public MRESReturn Hook_HandleScrambleTeams()
 	alert.SetInt("alert_type", 0);
 	alert.Fire();
 	PrintToChatAll("%T", "TF_TeamsScrambled", LANG_SERVER);
-	PlayTeamScrambleAlert();
+	EmitGameSoundToAll(GAMESOUND_ANNOUNCER_TEAM_SCRAMBLE);
 }
 
 public MRESReturn Hook_GiveNamedItem(int client, Handle returnVal, Handle params)

--- a/addons/sourcemod/scripting/tfgo/sound.sp
+++ b/addons/sourcemod/scripting/tfgo/sound.sp
@@ -53,13 +53,6 @@ public void EmitBombSeeGameSounds()
 	}
 }
 
-public void EmitPurchaseGameSound(int client)
-{
-	float origin[3];
-	GetClientAbsOrigin(client, origin);
-	EmitAmbientGameSound(GAMESOUND_PLAYER_PURCHASE, origin, client);
-}
-
 public Action Event_Pre_Teamplay_Broadcast_Audio(Event event, const char[] name, bool dontBroadcast)
 {
 	char sound[PLATFORM_MAX_PATH];

--- a/addons/sourcemod/scripting/tfgo/sound.sp
+++ b/addons/sourcemod/scripting/tfgo/sound.sp
@@ -1,64 +1,42 @@
-#define PLAYER_PURCHASE_SOUND "mvm/mvm_bought_upgrade.wav"
-
-static char g_BombPlantedAnnouncerAlerts[][PLATFORM_MAX_PATH] =  {
-	"vo/mvm_bomb_alerts01.mp3", 
-	"vo/mvm_bomb_alerts02.mp3"
+static char g_EngineerBombSeeGameSounds[][] =  {
+	"engineer_mvm_bomb_see01", 
+	"engineer_mvm_bomb_see02", 
+	"engineer_mvm_bomb_see03"
 };
 
-static char g_TeamScrambleAlerts[][PLATFORM_MAX_PATH] =  {
-	"vo/announcer_am_teamscramble01.mp3", 
-	"vo/announcer_am_teamscramble02.mp3", 
-	"vo/announcer_am_teamscramble03.mp3"
+static char g_HeavyBombSeeGameSounds[][] =  {
+	"heavy_mvm_bomb_see01"
 };
 
-static char g_BombPlantedEngineerAlerts[][PLATFORM_MAX_PATH] =  {
-	"vo/engineer_mvm_bomb_see01.mp3", 
-	"vo/engineer_mvm_bomb_see02.mp3", 
-	"vo/engineer_mvm_bomb_see03.mp3"
+static char g_MedicBombSeeGameSounds[][] =  {
+	"medic_mvm_bomb_see01", 
+	"medic_mvm_bomb_see02", 
+	"medic_mvm_bomb_see03"
 };
 
-static char g_BombPlantedHeavyAlerts[][PLATFORM_MAX_PATH] =  {
-	"vo/heavy_mvm_bomb_see01.mp3"
-};
-
-static char g_BombPlantedMedicAlerts[][PLATFORM_MAX_PATH] =  {
-	"vo/medic_mvm_bomb_see01.mp3", 
-	"vo/medic_mvm_bomb_see02.mp3", 
-	"vo/medic_mvm_bomb_see03.mp3"
-};
-
-static char g_BombPlantedSoldierAlerts[][PLATFORM_MAX_PATH] =  {
-	"vo/soldier_mvm_bomb_see01.mp3", 
-	"vo/soldier_mvm_bomb_see02.mp3", 
-	"vo/soldier_mvm_bomb_see03.mp3"
+static char g_SoldierBombSeeGameSounds[][] =  {
+	"soldier_mvm_bomb_see01", 
+	"soldier_mvm_bomb_see02", 
+	"soldier_mvm_bomb_see03"
 };
 
 public void PrecacheSounds()
 {
-	PrecacheSound(BOMB_WARNING_SOUND);
-	PrecacheSound(BOMB_EXPLOSION_SOUND);
-	PrecacheSound(PLAYER_PURCHASE_SOUND);
-	PrecacheSound(BOMB_BEEPING_SOUND);
+	PrecacheSound(SOUND_BOMB_BEEPING);
 	
-	for (int i = 0; i < sizeof(g_BombPlantedAnnouncerAlerts); i++)PrecacheSound(g_BombPlantedAnnouncerAlerts[i]);
-	for (int i = 0; i < sizeof(g_TeamScrambleAlerts); i++)PrecacheSound(g_TeamScrambleAlerts[i]);
-	for (int i = 0; i < sizeof(g_BombPlantedEngineerAlerts); i++)PrecacheSound(g_BombPlantedEngineerAlerts[i]);
-	for (int i = 0; i < sizeof(g_BombPlantedHeavyAlerts); i++)PrecacheSound(g_BombPlantedHeavyAlerts[i]);
-	for (int i = 0; i < sizeof(g_BombPlantedMedicAlerts); i++)PrecacheSound(g_BombPlantedMedicAlerts[i]);
-	for (int i = 0; i < sizeof(g_BombPlantedSoldierAlerts); i++)PrecacheSound(g_BombPlantedSoldierAlerts[i]);
+	PrecacheScriptSound(GAMESOUND_BOMB_EXPLOSION);
+	PrecacheScriptSound(GAMESOUND_BOMB_WARNING);
+	PrecacheScriptSound(GAMESOUND_PLAYER_PURCHASE);
+	PrecacheScriptSound(GAMESOUND_ANNOUNCER_BOMB_PLANTED);
+	PrecacheScriptSound(GAMESOUND_ANNOUNCER_TEAM_SCRAMBLE);
+	
+	for (int i = 0; i < sizeof(g_EngineerBombSeeGameSounds); i++) PrecacheScriptSound(g_EngineerBombSeeGameSounds[i]);
+	for (int i = 0; i < sizeof(g_HeavyBombSeeGameSounds); i++) PrecacheScriptSound(g_HeavyBombSeeGameSounds[i]);
+	for (int i = 0; i < sizeof(g_MedicBombSeeGameSounds); i++) PrecacheScriptSound(g_MedicBombSeeGameSounds[i]);
+	for (int i = 0; i < sizeof(g_SoldierBombSeeGameSounds); i++) PrecacheScriptSound(g_SoldierBombSeeGameSounds[i]);
 }
 
-public void PlayAnnouncerBombAlert()
-{
-	EmitSoundToAll(g_BombPlantedAnnouncerAlerts[GetRandomInt(0, sizeof(g_BombPlantedAnnouncerAlerts) - 1)], _, SNDCHAN_VOICE_BASE); // SNDCHAN_VOICE_BASE = CHAN_VOICE2
-}
-
-public void PlayTeamScrambleAlert()
-{
-	EmitSoundToAll(g_TeamScrambleAlerts[GetRandomInt(0, sizeof(g_TeamScrambleAlerts) - 1)], _, SNDCHAN_VOICE_BASE);
-}
-
-public void ShoutBombWarnings()
+public void EmitBombSeeGameSounds()
 {
 	for (int client = 1; client <= MaxClients; client++)
 	{
@@ -66,20 +44,20 @@ public void ShoutBombWarnings()
 		{
 			switch (TF2_GetPlayerClass(client))
 			{
-				case TFClass_Engineer:EmitSoundToAll(g_BombPlantedEngineerAlerts[GetRandomInt(0, sizeof(g_BombPlantedEngineerAlerts) - 1)], _, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
-				case TFClass_Heavy:EmitSoundToAll(g_BombPlantedHeavyAlerts[GetRandomInt(0, sizeof(g_BombPlantedHeavyAlerts) - 1)], _, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
-				case TFClass_Medic:EmitSoundToAll(g_BombPlantedMedicAlerts[GetRandomInt(0, sizeof(g_BombPlantedMedicAlerts) - 1)], _, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
-				case TFClass_Soldier:EmitSoundToAll(g_BombPlantedSoldierAlerts[GetRandomInt(0, sizeof(g_BombPlantedSoldierAlerts) - 1)], _, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
+				case TFClass_Engineer: EmitGameSoundToAll(g_EngineerBombSeeGameSounds[GetRandomInt(0, sizeof(g_EngineerBombSeeGameSounds) - 1)]);
+				case TFClass_Heavy: EmitGameSoundToAll(g_HeavyBombSeeGameSounds[GetRandomInt(0, sizeof(g_HeavyBombSeeGameSounds) - 1)]);
+				case TFClass_Medic: EmitGameSoundToAll(g_MedicBombSeeGameSounds[GetRandomInt(0, sizeof(g_MedicBombSeeGameSounds) - 1)]);
+				case TFClass_Soldier: EmitGameSoundToAll(g_SoldierBombSeeGameSounds[GetRandomInt(0, sizeof(g_SoldierBombSeeGameSounds) - 1)]);
 			}
 		}
 	}
 }
 
-public void PlayPurchaseSound(int client)
+public void EmitPurchaseGameSound(int client)
 {
 	float origin[3];
 	GetClientAbsOrigin(client, origin);
-	EmitAmbientSound(PLAYER_PURCHASE_SOUND, origin);
+	EmitAmbientGameSound(GAMESOUND_PLAYER_PURCHASE, origin, client);
 }
 
 public Action Event_Pre_Teamplay_Broadcast_Audio(Event event, const char[] name, bool dontBroadcast)

--- a/addons/sourcemod/scripting/tfgo/stocks.sp
+++ b/addons/sourcemod/scripting/tfgo/stocks.sp
@@ -45,7 +45,7 @@ stock void TF2_ForceRoundWin(TFTeam team, int winReason, bool forceMapReset = tr
 	RemoveEntity(entity);
 }
 
-stock void TF2_Explode(int attacker = -1, float origin[3], float damage, float radius, const char[] particle, const char[] sound)
+stock void TF2_Explode(int attacker = -1, float origin[3], float damage, float radius, const char[] particle = NULL_STRING, const char[] sound = NULL_STRING)
 {
 	int bomb = CreateEntityByName("tf_generic_bomb");
 	DispatchKeyValueVector(bomb, "origin", origin);


### PR DESCRIPTION
This changes almost all TF2 sounds in the plugin to use sound scripts instead.
This saves us from having to store the paths to all related sound files as well as manually specifying the channel, level, volume and pitch of the sound when playing it to clients.