### PR TITLE
Use keyvalue to prevent a team from winning

### DIFF
--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -476,23 +476,18 @@ public void OnEntityCreated(int entity, const char[] classname)
 	}
 	else if (StrEqual(classname, "team_control_point_master"))
 	{
-		SDKHook(entity, SDKHook_Spawn, Hook_ControlPointMaster_Spawn);
+		DispatchKeyValue(entity, "cpm_restrict_team_cap_win", "1");
 	}
 }
 
 public void Hook_LogicArena_Spawn(int entity)
 {
-	SetEntPropFloat(entity, Prop_Data, "m_flTimeToEnableCapPoint", 0.0);
+	DispatchKeyValueFloat(entity, "CapEnableDelay", 0.0);
 }
 
 public void Hook_CaptureArea_Spawn(int entity)
 {
 	SetEntPropFloat(entity, Prop_Data, "m_flCapTime", GetEntPropFloat(entity, Prop_Data, "m_flCapTime") / 2);
-}
-
-public void Hook_ControlPointMaster_Spawn(int entity)
-{
-	DispatchKeyValue(entity, "cpm_restrict_team_cap_win", "1");
 }
 
 public Action Event_Player_Team(Event event, const char[] name, bool dontBroadcast)

--- a/addons/sourcemod/scripting/tfgo/sdk.sp
+++ b/addons/sourcemod/scripting/tfgo/sdk.sp
@@ -177,39 +177,12 @@ public MRESReturn Hook_SetWinningTeam(Handle params)
 	TFTeam team = DHookGetParam(params, 1);
 	int winReason = DHookGetParam(params, 2);
 	
-	// Bomb is detonated but game wants to award elimination win on multi-CP maps, rewrite it to make it look like a capture
-	if (g_IsBombDetonated && winReason == WinReason_Elimination)
-	{
-		DHookSetParam(params, 2, WinReason_PointCaptured);
-		return MRES_ChangedHandled;
-	}
-	
-	// Bomb is defused but game wants to award elimination win on multi-CP maps, rewrite it to make it look like a capture
-	else if (g_IsBombDefused && team != g_BombPlantingTeam && winReason == WinReason_Elimination)
-	{
-		DHookSetParam(params, 2, WinReason_PointCaptured);
-		return MRES_ChangedHandled;
-	}
-	// Sometimes the game is stupid and gives defuse win to the planting team, this should prevent that
-	else if (g_IsBombDefused && team == g_BombPlantingTeam)
-	{
+	// Allow planting team to die
+	if (g_IsBombPlanted && team != g_BombPlantingTeam && winReason == WinReason_Elimination)
 		return MRES_Supercede;
-	}
 	
-	// If this is a capture win from planting the bomb we supercede it, otherwise ignore to grant the defusal win
-	else if (g_IsBombPlanted && team == g_BombPlantingTeam && (winReason == WinReason_PointCaptured || winReason == WinReason_AllPointsCaptured))
-	{
-		return MRES_Supercede;
-	}
-	
-	// Planting team was killed while the bomb was active, do not give elimination win to enemy team
-	else if (g_IsBombPlanted && team != g_BombPlantingTeam && winReason == WinReason_Elimination)
-	{
-		return MRES_Supercede;
-	}
-	
-	// Stalemate
-	else if (team == TFTeam_Unassigned && winReason == WinReason_Stalemate)
+	// Award no cash on a stalemate
+	if (team == TFTeam_Unassigned && winReason == WinReason_Stalemate)
 	{
 		TFGOTeam red = TFGOTeam(TFTeam_Red);
 		TFGOTeam blue = TFGOTeam(TFTeam_Blue);
@@ -220,11 +193,7 @@ public MRESReturn Hook_SetWinningTeam(Handle params)
 		return MRES_Ignored;
 	}
 	
-	// Everything else that doesn't require superceding e.g. eliminating the enemy team
-	else
-	{
-		return MRES_Ignored;
-	}
+	return MRES_Ignored;
 }
 
 public MRESReturn Hook_HandleSwitchTeams()


### PR DESCRIPTION
Turns out ``team_control_point_master`` has a keyvalue called ``cpm_restrict_team_cap_win`` which doesn't end the round if a control point gets captured, meaning we don't have to do a million checks and rewrite win reasons in ``CTFGameRules::SetWinningTeam`` anymore. The function is still required to prevent a round win from eliminating the planting team, though.