### PR TITLE
Fix minigun headshot earrape

### DIFF
--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -274,6 +274,8 @@ public void OnPluginStart()
 	AddCommandListener(CommandListener_Build, "build");
 	AddCommandListener(CommandListener_Destroy, "destroy");
 	
+	AddNormalSoundHook(NormalSoundHook);
+	
 	CAddColor("negative", 0xEA4141);
 	CAddColor("positive", 0xA2FF47);
 	

--- a/addons/sourcemod/scripting/tfgo/sound.sp
+++ b/addons/sourcemod/scripting/tfgo/sound.sp
@@ -1,3 +1,12 @@
+static char g_IgnoredSounds[][] = {
+	// Spatialized minigun crit sounds from headshots loop forever so we block them entirely
+	")weapons/dragon_gun_motor_loop_crit.wav",
+	")weapons/gatling_shoot_crit.wav",
+	")weapons/minifun_shoot_crit.wav",
+	")weapons/minigun_shoot_crit.wav",
+	")weapons/tomislav_shoot_crit.wav"
+};
+
 static char g_EngineerBombSeeGameSounds[][] =  {
 	"engineer_mvm_bomb_see01", 
 	"engineer_mvm_bomb_see02", 
@@ -79,6 +88,17 @@ public Action Event_Pre_Teamplay_Broadcast_Audio(Event event, const char[] name,
 	{
 		g_CurrentMusicKit.StopMusicForAll(Music_StartRound);
 		g_CurrentMusicKit.PlayMusicToAll(Music_StartAction);
+	}
+	
+	return Plugin_Continue;
+}
+
+public Action NormalSoundHook(int clients[MAXPLAYERS], int &numClients, char sample[PLATFORM_MAX_PATH], int &entity, int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)
+{
+	for (int i = 0; i < sizeof(g_IgnoredSounds); i++)
+	{
+		if (StrEqual(sample, g_IgnoredSounds[i]))
+			return Plugin_Handled;
 	}
 	
 	return Plugin_Continue;


### PR DESCRIPTION
Whenever a headshot occurs, the server emits a spatialized crit burst sound. Valve never really intended this to be used with looping sounds and thus has no code in place to stop the sound, causing minigun crit sounds to get stuck in place and ear-rape everyone in the general location. Only sane solution is to just ignore these sounds entirely, as that is what Valve already does server-side.

Technically applies to Flame Throwers as well but we can safely ignore them as they cannot headshot anyway.