### PR TITLE
Add support for attack/defend style maps

### DIFF
--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -176,7 +176,6 @@ bool g_IsBombPlanted;
 
 TFTeam g_BombPlantingTeam;
 bool g_HasPlayerSuicided[TF_MAXPLAYERS + 1];
-bool g_IsTeamAttacking[view_as<int>(TFTeam_Blue) + 1];
 
 // ConVars
 ConVar tfgo_use_hitlocation_dmg;
@@ -360,9 +359,9 @@ public void OnMapStart()
 		CalculateDynamicBuyZones();
 	}
 	
-	for (int i = 0; i < sizeof(g_IsTeamAttacking); i++)
+	for (int i = view_as<int>(TFTeam_Red); i <= view_as<int>(TFTeam_Blue); i++)
 	{
-		g_IsTeamAttacking[i] = false;
+		TFGOTeam(view_as<TFTeam>(i)).IsAttacking = false;
 	}
 }
 
@@ -529,18 +528,18 @@ Action SDKHook_TriggerCaptureArea_Spawn(int entity)
 Action SDKHook_TeamControlPoint_Spawn(int entity)
 {
 	// Point default owner is the defending team, there may be multiple defending teams
-	int defaultOwner = GetEntProp(entity, Prop_Data, "m_iDefaultOwner");
+	TFTeam defaultOwner = view_as<TFTeam>(GetEntProp(entity, Prop_Data, "m_iDefaultOwner"));
 	
-	if (view_as<TFTeam>(defaultOwner) == TFTeam_Unassigned)
+	if (defaultOwner == TFTeam_Unassigned)
 	{
 		// Neutral CP, both teams are attacking
-		g_IsTeamAttacking[view_as<int>(TFTeam_Red)] = true;
-		g_IsTeamAttacking[view_as<int>(TFTeam_Blue)] = true;
+		TFGOTeam(TFTeam_Red).IsAttacking = true;
+		TFGOTeam(TFTeam_Blue).IsAttacking = true;
 	}
 	else
 	{
 		// RED or BLU owns this CP, mark the enemy as attacker
-		g_IsTeamAttacking[TF2_GetEnemyTeam(view_as<TFTeam>(defaultOwner))] = true;
+		TFGOTeam(TF2_GetEnemyTeam(defaultOwner)).IsAttacking = true;
 	}
 }
 	

--- a/addons/sourcemod/scripting/tfgo/buymenu.sp
+++ b/addons/sourcemod/scripting/tfgo/buymenu.sp
@@ -292,6 +292,9 @@ int MenuHandler_EquipmentBuyMenu(Menu menu, MenuAction action, int param1, int p
 			}
 			else if (StrEqual(info, INFO_DEFUSEKIT))
 			{
+				if (!g_IsTeamAttacking[GetClientTeam(param1)])
+					return ITEMDRAW_IGNORE;
+				
 				if (player.HasDefuseKit || player.Account < DEFUSEKIT_PRICE)
 					return ITEMDRAW_DISABLED;
 			}

--- a/addons/sourcemod/scripting/tfgo/buymenu.sp
+++ b/addons/sourcemod/scripting/tfgo/buymenu.sp
@@ -292,10 +292,9 @@ int MenuHandler_EquipmentBuyMenu(Menu menu, MenuAction action, int param1, int p
 			}
 			else if (StrEqual(info, INFO_DEFUSEKIT))
 			{
-				if (!g_IsTeamAttacking[GetClientTeam(param1)])
+				if (!TFGOTeam(TF2_GetClientTeam(param1)).IsAttacking)
 					return ITEMDRAW_IGNORE;
-				
-				if (player.HasDefuseKit || player.Account < DEFUSEKIT_PRICE)
+				else if (player.HasDefuseKit || player.Account < DEFUSEKIT_PRICE)
 					return ITEMDRAW_DISABLED;
 			}
 			

--- a/addons/sourcemod/scripting/tfgo/methodmaps.sp
+++ b/addons/sourcemod/scripting/tfgo/methodmaps.sp
@@ -6,6 +6,7 @@ static bool PlayerDefuseKits[TF_MAXPLAYERS + 1][view_as<int>(TFClass_Engineer) +
 static Menu ActiveBuyMenus[TF_MAXPLAYERS + 1];
 
 static int TeamConsecutiveLosses[view_as<int>(TFTeam_Blue) + 1] =  { STARTING_CONSECUTIVE_LOSSES, ... };
+static bool IsTeamAttacking[view_as<int>(TFTeam_Blue) + 1];
 
 methodmap TFGOPlayer
 {
@@ -381,6 +382,18 @@ methodmap TFGOTeam
 		public get()
 		{
 			return tfgo_cash_team_loser_bonus.IntValue + tfgo_cash_team_loser_bonus_consecutive_rounds.IntValue * this.ConsecutiveLosses;
+		}
+	}
+	
+	property bool IsAttacking
+	{
+		public get()
+		{
+			return IsTeamAttacking[this];
+		}
+		public set(bool val)
+		{
+			IsTeamAttacking[this] = val;
 		}
 	}
 	

--- a/addons/sourcemod/scripting/tfgo/sdk.sp
+++ b/addons/sourcemod/scripting/tfgo/sdk.sp
@@ -233,7 +233,7 @@ public MRESReturn DHook_SetWinningTeam(Handle params)
 		for (int i = view_as<int>(TFTeam_Red); i <= view_as<int>(TFTeam_Blue); i++)
 		{
 			// Only a non-attacking team can get the time win, and only if this stalemate is a result of the timer running out
-			if (!g_IsTeamAttacking[i] && GetAlivePlayerCount() > 0)
+			if (!TFGOTeam(view_as<TFTeam>(i)).IsAttacking && GetAlivePlayerCount() > 0)
 			{
 				DHookSetParam(params, 1, i);
 				DHookSetParam(params, 2, WinReason_Time);

--- a/addons/sourcemod/scripting/tfgo/sdk.sp
+++ b/addons/sourcemod/scripting/tfgo/sdk.sp
@@ -225,7 +225,22 @@ public MRESReturn DHook_SetWinningTeam(Handle params)
 	
 	// Allow planting team to die
 	if (g_IsBombPlanted && team != g_BombPlantingTeam && winReason == WinReason_Elimination)
+	{
 		return MRES_Supercede;
+	}
+	else if (winReason == WinReason_Stalemate)
+	{
+		for (int i = view_as<int>(TFTeam_Red); i <= view_as<int>(TFTeam_Blue); i++)
+		{
+			// Only a non-attacking team can get the time win, and only if this stalemate is a result of the timer running out
+			if (!g_IsTeamAttacking[i] && GetAlivePlayerCount() > 0)
+			{
+				DHookSetParam(params, 1, i);
+				DHookSetParam(params, 2, WinReason_Time);
+				return MRES_ChangedOverride;
+			}
+		}
+	}
 	
 	return MRES_Ignored;
 }

--- a/addons/sourcemod/scripting/tfgo/stocks.sp
+++ b/addons/sourcemod/scripting/tfgo/stocks.sp
@@ -78,6 +78,27 @@ stock int FindStringIndex2(int tableidx, const char[] str)
 	return INVALID_STRING_INDEX;
 }
 
+stock int GetAlivePlayerCount()
+{
+	int count = 0;
+	for (int client = 1; client <= MaxClients; client++)
+	{
+		if (IsClientInGame(client) && IsPlayerAlive(client))
+			count++;
+	}
+	return count;
+}
+
+stock TFTeam TF2_GetEnemyTeam(TFTeam team)
+{
+	switch (team)
+	{
+		case TFTeam_Red: return TFTeam_Blue;
+		case TFTeam_Blue: return TFTeam_Red;
+		default: return team;
+	}
+}
+
 stock int TF2_GetAlivePlayerCountForTeam(TFTeam team)
 {
 	int count = 0;

--- a/addons/sourcemod/translations/tfgo.phrases.txt
+++ b/addons/sourcemod/translations/tfgo.phrases.txt
@@ -265,6 +265,10 @@
 	{
 		"en"	"{positive}+$%d{default}: Team award for eliminating the enemy team."
 	}
+	"Team_Cash_Award_Win_Time"
+	{
+		"en"	"{positive}+$%d{default}: Team award for winning by running down the clock."
+	}
 	"Team_Cash_Award_Win_Defuse_Bomb"
 	{
 		"en"	"{positive}+$%d{default}: Team award for winning by defusing the bomb."
@@ -277,7 +281,11 @@
 	{
 		"en"	"{positive}+$%d{default}: Team award for planting the bomb."
 	}
-	"Team_Cash_Award_no_income"
+	"Team_Cash_Award_no_income_stalemate"
+	{
+		"en"	"{negative}0{default}: No income for triggering a stalemate."
+	}
+	"Team_Cash_Award_no_income_out_of_time"
 	{
 		"en"	"{negative}0{default}: No income for running out of time and surviving."
 	}


### PR DESCRIPTION
Maps where one team owns all the capture points do not work very well with the game mode right now. Someone can stall/hide and let the round timer run out, which causes a loss for both teams, despite one of them being the designated defenders.

This PR adds the timer win for a defending team. The plugin will now search for capture points and determines whether a team can attack it and mark them as the attacking team.
Attacking teams **have** to plant the bomb or kill the enemy team, or else they will receive no money once the round timer reaches 0.
Neutral capture points will mark both teams as the attacking team.

This also adds a different message for triggering a death match-induced stalemate.