### PR TITLE
Allow configuring headshots on a per-weapon basis

### DIFF
--- a/addons/sourcemod/configs/tfgo/tfgo.cfg
+++ b/addons/sourcemod/configs/tfgo/tfgo.cfg
@@ -526,7 +526,7 @@
 		}
 		"424"	// Tomislav
 		{
-			"price"				"4900"
+			"price"				"4750"
 			"kill_award"		"100"
 			"armor_penetration"	"0.75"
 		}

--- a/addons/sourcemod/configs/tfgo/tfgo.cfg
+++ b/addons/sourcemod/configs/tfgo/tfgo.cfg
@@ -511,35 +511,30 @@
 			"price"				"4750"
 			"kill_award"		"100"
 			"armor_penetration"	"0.75"
-			"can_headshot"		"1"
 		}
 		"41"	// Natascha
 		{
 			"price"				"4450"
 			"kill_award"		"100"
 			"armor_penetration"	"0.75"
-			"can_headshot"		"1"
 		}
 		"312"	// Brass Beast
 		{
 			"price"				"4450"
 			"kill_award"		"100"
 			"armor_penetration"	"0.75"
-			"can_headshot"		"1"
 		}
 		"424"	// Tomislav
 		{
 			"price"				"4900"
 			"kill_award"		"100"
 			"armor_penetration"	"0.75"
-			"can_headshot"		"1"
 		}
 		"811"	// Huo-Long Heater
 		{
 			"price"				"4000"
 			"kill_award"		"100"
 			"armor_penetration"	"0.75"
-			"can_headshot"		"1"
 		}
 		
 		

--- a/addons/sourcemod/configs/tfgo/tfgo.cfg
+++ b/addons/sourcemod/configs/tfgo/tfgo.cfg
@@ -3,55 +3,51 @@
 	// WEAPON CONFIGURATION:
 	//  Defines certain properties for weapons.
 	//
+	// The key of the configuration entry is the item definition index of the weapon.
+	//
 	// Possible attributes:
-	//  defindex <int>				- The item definition index of this weapon (required)
 	//  price <int>					- The price of the weapon in the buy menu, 0 prevents this weapon from being buyable (default: 0)
 	//  kill_award <int>			- The amount of money earned on kill (default: 300)
 	//  armor_penetration <float>	- Percentage of armor this weapon can bypass, 0.0 = no damage, 1.0 = full armor penetration (default: 1.0)
 	//  is_default <bool>			- Whether players spawn with this weapon when they reset (default: 0)
+	//  can_headshot <bool>			- Whether this weapon can deal crits on headshot (default: 0)
 	//
 	"Weapons"
 	{
 		// Scout - Primary
 		 
-		"Weapon"	// Scattergun
+		"13"	// Scattergun
 		{
-			"defindex"			"13"
 			"price"				"3300"
 			"kill_award"		"200"
 			"armor_penetration"	"0.7"
 		}
-		"Weapon"	// Force-A-Nature
+		"45"	// Force-A-Nature
 		{
-			"defindex"			"45"
 			"price"				"3150"
 			"kill_award"		"200"
 			"armor_penetration"	"0.7"
 		}
-		"Weapon"	// Shortstop
+		"220"	// Shortstop
 		{
-			"defindex"			"220"
 			"price"				"3150"
 			"kill_award"		"300"
 			"armor_penetration"	"0.7"
 		}
-		"Weapon"	// Soda Popper
+		"448"	// Soda Popper
 		{
-			"defindex"			"448"
 			"price"				"3150"
 			"kill_award"		"200"
 			"armor_penetration"	"0.7"
 		}
-		"Weapon"	// Baby Face's Blaster
+		"772"	// Baby Face's Blaster
 		{
-			"defindex"			"772"
 			"price"				"2850"
 			"kill_award"		"300"
 			"armor_penetration"	"0.7"
 		}
-		"Weapon"	// Back Scatter
+		"1103"	// Back Scatter
 		{
-			"defindex"			"1103"
 			"price"				"2550"
 			"kill_award"		"200"
 			"armor_penetration"	"0.7"
@@ -60,45 +56,41 @@
 		
 		// Scout - Secondary
 		
-		"Weapon"	// Scout's Pistol
+		"23"	// Scout's Pistol
 		{
-			"defindex"			"23"
 			"kill_award"		"300"
 			"armor_penetration" "0.475"
 			"is_default"		"1"
+			"can_headshot"		"1"
 		}
-		"Weapon"	// Bonk! Atomic Punch
+		"46"	// Bonk! Atomic Punch
 		{
-			"defindex"	"46"
 			"price"		"500"
 		}
-		"Weapon"	// Crit-a-Cola
+		"163"	// Crit-a-Cola
 		{
-			"defindex"	"163"
 			"price"		"500"
 		}
-		"Weapon"	// Mad Milk
+		"222"	// Mad Milk
 		{
-			"defindex"	"222"
 			"price"		"900"
 		}
-		"Weapon"	// Winger
+		"449"	// Winger
 		{
-			"defindex"			"449"
 			"price"				"700"
 			"kill_award"		"400"
 			"armor_penetration"	"0.525"
+			"can_headshot"		"1"
 		}
-		"Weapon"	// Pretty Boy's Pocket Pistol 
+		"773"	// Pretty Boy's Pocket Pistol 
 		{
-			"defindex"			"773"
 			"price"				"700"
 			"kill_award"		"400"
 			"armor_penetration"	"0.525"
+			"can_headshot"		"1"
 		}
-		"Weapon"	// The Flying Guillotine 
+		"812"	// The Flying Guillotine 
 		{
-			"defindex"			"812"
 			"price"				"500"
 			"kill_award"		"500"
 			"armor_penetration"	"0.525"
@@ -107,58 +99,50 @@
 		
 		// Scout - Melee
 		 
-		"Weapon"	// Sandman
+		"44"	// Sandman
 		{
-			"defindex"			"44"
 			"price"				"700"
 			"kill_award"		"700"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Holy Mackerel
+		"221"	// Holy Mackerel
 		{
-			"defindex"			"221"
 			"price"				"50"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Candy Cane
+		"317"	// Candy Cane
 		{
-			"defindex"			"317"
 			"price"				"700"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Boston Basher
+		"325"	// Boston Basher
 		{
-			"defindex"			"325"
 			"price"				"600"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Sun-on-a-Stick
+		"349"	// Sun-on-a-Stick
 		{
-			"defindex"			"349"
 			"price"				"500"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Fan O'War
+		"355"	// Fan O'War
 		{
-			"defindex"			"355"
 			"price"				"500"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Atomizer
+		"450"	// Atomizer
 		{
-			"defindex"			"450"
 			"price"				"700"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Wrap Assassin
+		"648"	// Wrap Assassin
 		{
-			"defindex"			"648"
 			"price"				"800"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
@@ -167,56 +151,48 @@
 		
 		// Soldier - Primary
 		 
-		"Weapon"	// Rocket Launcher
+		"18"	// Rocket Launcher
 		{
-			"defindex"			"18"
 			"price"				"4750"
 			"kill_award"		"100"
 			"armor_penetration"	"0.6"
 		}
-		"Weapon"	// Direct Hit
+		"127"	// Direct Hit
 		{
-			"defindex"			"127"
 			"price"				"4600"
 			"kill_award"		"100"
 			"armor_penetration"	"0.6"
 		}
-		"Weapon"	// Black Box
+		"228"	// Black Box
 		{
-			"defindex"			"228"
 			"price"				"4600"
 			"kill_award"		"100"
 			"armor_penetration"	"0.6"
 		}
-		"Weapon"	// Rocket Jumper
+		"237"	// Rocket Jumper
 		{
-			"defindex"			"237"
 			"price"				"700"
 		}
-		"Weapon"	// Liberty Launcher
+		"414"	// Liberty Launcher
 		{
-			"defindex"			"414"
 			"price"				"4150"
 			"kill_award"		"100"
 			"armor_penetration"	"0.6"
 		}
-		"Weapon"	// Cow Mangler 5000
+		"441"	// Cow Mangler 5000
 		{
-			"defindex"			"441"
 			"price"				"4600"
 			"kill_award"		"100"
 			"armor_penetration"	"0.6"
 		}
-		"Weapon"	// Beggar's Bazooka 
+		"730"	// Beggar's Bazooka 
 		{
-			"defindex"			"730"
 			"price"				"4300"
 			"kill_award"		"100"
 			"armor_penetration"	"0.6"
 		}
-		"Weapon"	// Air Strike
+		"1104"	// Air Strike
 		{
-			"defindex"			"1104"
 			"price"				"3850"
 			"kill_award"		"200"
 			"armor_penetration"	"0.6"
@@ -225,42 +201,35 @@
 		
 		// Soldier - Secondary
 		 
-		"Weapon"	// Soldier's Shotgun
+		"10"	// Soldier's Shotgun
 		{
-			"defindex"			"10"
 			"armor_penetration"	"0.75"
 			"kill_award"		"400"
 			"is_default"		"1"
 		}
-		"Weapon"	// Buff Banner
+		"129"	// Buff Banner
 		{
-			"defindex"	"129"
 			"price"		"700"
 		}
-		"Weapon"	// Gunboats
+		"133"	// Gunboats
 		{
-			"defindex"	"133"
 			"price"		"500"
 		}
-		"Weapon"	// Battalion's Backup
+		"226"	// Battalion's Backup
 		{
-			"defindex"	"226"
 			"price"		"700"
 		}
-		"Weapon"	// Concheror
+		"354"	// Concheror
 		{
-			"defindex"	"354"
 			"price"		"900"
 		}
-		"Weapon"	// Righteous Bison
+		"442"	// Righteous Bison
 		{
-			"defindex"		"442"
 			"kill_award"	"500"
 			"price"			"700"
 		}
-		"Weapon"	// Mantreads
+		"444"	// Mantreads
 		{
-			"defindex"			"444"
 			"price"				"500"
 			"kill_award"		"1500"
 			"armor_penetration"	"0.975"
@@ -269,30 +238,26 @@
 		
 		// Soldier - Melee
 		 
-		"Weapon"	// Equalizer
+		"128"	// Equalizer
 		{
-			"defindex"			"128"
 			"price"				"600"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Market Gardener
+		"416"	// Market Gardener
 		{
-			"defindex"			"416"
 			"price"				"500"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Disciplinary Action 
+		"447"	// Disciplinary Action 
 		{
-			"defindex"			"447"
 			"price"				"700"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Escape Plan 
+		"775"	// Escape Plan 
 		{
-			"defindex"			"775"
 			"price"				"800"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
@@ -301,37 +266,32 @@
 		
 		// Pyro - Primary
 		 
-		"Weapon"	// Flame thrower
+		"21"	// Flame thrower
 		{
-			"defindex"			"21"
 			"price"				"4250"
 			"kill_award"		"200"
 			"armor_penetration"	"1.0"
 		}
-		"Weapon"	// Backburner
+		"40"	// Backburner
 		{
-			"defindex"			"40"
 			"price"				"4100"
 			"kill_award"		"200"
 			"armor_penetration"	"1.0"
 		}
-		"Weapon"	// Degreaser
+		"215"	// Degreaser
 		{
-			"defindex"			"215"
 			"price"				"3950"
 			"kill_award"		"200"
 			"armor_penetration"	"1.0"
 		}
-		"Weapon"	// Phlogistinator
+		"594"	// Phlogistinator
 		{
-			"defindex"			"594"
 			"price"				"4100"
 			"kill_award"		"200"
 			"armor_penetration"	"1.0"
 		}
-		"Weapon"	// Dragon's Fury
+		"1178"	// Dragon's Fury
 		{
-			"defindex"			"1178"
 			"price"				"3950"
 			"kill_award"		"300"
 			"armor_penetration"	"0.6"
@@ -340,51 +300,44 @@
 		
 		// Pyro - Secondary
 		 
-		"Weapon"	// Pyro's Shotgun
+		"12"	// Pyro's Shotgun
 		{
-			"defindex"			"12"
 			"armor_penetration"	"0.75"
 			"kill_award"		"400"
 			"is_default"		"1"
 		}
-		"Weapon"	// Flare Gun
+		"39"	// Flare Gun
 		{
-			"defindex"			"39"
 			"price"				"900"
 			"kill_award"		"500"
 			"armor_penetration"	"0.65"
 		}
-		"Weapon"	// Detonator
+		"351"	// Detonator
 		{
-			"defindex"			"351"
 			"price"				"900"
 			"kill_award"		"500"
 			"armor_penetration"	"0.65"
 		}
-		"Weapon"	// Manmelter
+		"595"	// Manmelter
 		{
-			"defindex"			"595"
 			"price"				"700"
 			"kill_award"		"600"
 			"armor_penetration"	"0.65"
 		}
-		"Weapon"	// Scorch Shot
+		"740"	// Scorch Shot
 		{
-			"defindex"			"740"
 			"price"				"900"
 			"kill_award"		"500"
 			"armor_penetration"	"0.65"
 		}
-		"Weapon"	// Thermal Thruster
+		"1179"	// Thermal Thruster
 		{
-			"defindex"			"1179"
 			"price"				"700"
 			"kill_award"		"1500"
 			"armor_penetration"	"0.975"
 		}
-		"Weapon"	// Gas Passer
+		"1180"	// Gas Passer
 		{
-			"defindex"		"1180"
 			"kill_award"	"1500"
 			"price"			"300"
 		}
@@ -392,58 +345,50 @@
 		
 		// Pyro - Melee
 		 
-		"Weapon"	// Axtinguisher
+		"38"	// Axtinguisher
 		{
-			"defindex"			"38"
 			"price"				"700"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Homewrecker
+		"153"	// Homewrecker
 		{
-			"defindex"			"153"
 			"price"				"700"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Powerjack
+		"214"	// Powerjack
 		{
-			"defindex"			"214"
 			"price"				"800"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Back Scratcher
+		"326"	// Back Scratcher
 		{
-			"defindex"			"326"
 			"price"				"700"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Sharpened Volcano Fragment 
+		"348"	// Sharpened Volcano Fragment 
 		{
-			"defindex"			"348"
 			"price"				"500"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Third Degree
+		"593"	// Third Degree
 		{
-			"defindex"			"593"
 			"price"				"500"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Neon Annihilator 
+		"813"	// Neon Annihilator 
 		{
-			"defindex"			"813"
 			"price"				"600"
 			"kill_award"		"700"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	//  Hot Hand
+		"1181"	//  Hot Hand
 		{
-			"defindex"			"1181"
 			"price"				"600"
 			"kill_award"		"700"
 			"armor_penetration"	"0.85"
@@ -452,35 +397,30 @@
 		
 		// Demoman - Primary
 		 
-		"Weapon"	// Grenade Launcher
+		"19"	// Grenade Launcher
 		{
-			"defindex"			"19"
 			"price"				"2250"
 			"kill_award"		"300"
 			"armor_penetration"	"0.6"
 		}
-		"Weapon"	// Loch-n-Load
+		"308"	// Loch-n-Load
 		{
-			"defindex"			"308"
 			"price"				"2250"
 			"kill_award"		"300"
 			"armor_penetration"	"0.6"
 		}
-		"Weapon"	// Bootlegger
+		"608"	// Bootlegger
 		{
-			"defindex"		"608"
 			"is_default"	"1"
 		}
-		"Weapon"	// Loose Cannon
+		"996"	// Loose Cannon
 		{
-			"defindex"			"996"
 			"price"				"2250"
 			"kill_award"		"400"
 			"armor_penetration"	"0.6"
 		}
-		"Weapon"	// Iron Bomber
+		"1151"	// Iron Bomber
 		{
-			"defindex"			"1151"
 			"price"				"2250"
 			"kill_award"		"300"
 			"armor_penetration"	"0.6"
@@ -489,48 +429,41 @@
 		
 		// Demoman - Secondary
 		 
-		"Weapon"	// Stickybomb Launcher
+		"20"	// Stickybomb Launcher
 		{
-			"defindex"			"20"
 			"price"				"4100"
 			"kill_award"		"100"
 			"armor_penetration"	"0.6"
 		}
-		"Weapon"	// Scottish Resistance 
+		"130"	// Scottish Resistance 
 		{
-			"defindex"			"130"
 			"price"				"3800"
 			"kill_award"		"100"
 			"armor_penetration"	"0.6"
 		}
-		"Weapon"	// Chargin' Targe
+		"131"	// Chargin' Targe
 		{
-			"defindex"		"131"
 			"kill_award"	"900"
 			"is_default"	"1"
 		}
-		"Weapon"	// Sticky Jumper 
+		"265"	// Sticky Jumper 
 		{
-			"defindex"	"265"
 			"price"		"500"
 		}
-		"Weapon"	// Splendid Screen 
+		"406"	// Splendid Screen 
 		{
-			"defindex"			"406"
 			"price"				"700"
 			"kill_award"		"900"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Tide Turner 
+		"1099"	// Tide Turner 
 		{
-			"defindex"			"1099"
 			"price"				"700"
 			"kill_award"		"900"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Quickiebomb Launcher 
+		"1150"	// Quickiebomb Launcher 
 		{
-			"defindex"			"1150"
 			"price"				"3950"
 			"kill_award"		"100"
 			"armor_penetration"	"0.6"
@@ -539,37 +472,32 @@
 		
 		// Demoman - Melee
 		 
-		"Weapon"	// Eyelander
+		"132"	// Eyelander
 		{
-			"defindex"			"132"
 			"price"				"800"
 			"kill_award"		"500"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Scotsman's Skullcutter 
+		"172"	// Scotsman's Skullcutter 
 		{
-			"defindex"			"172"
 			"price"				"700"
 			"kill_award"		"500"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Ullapool Caber
+		"307"	// Ullapool Caber
 		{
-			"defindex"			"307"
 			"price"				"500"
 			"kill_award"		"600"
 			"armor_penetration"	"0.6"
 		}
-		"Weapon"	// Claidheamh Mòr
+		"327"	// Claidheamh Mòr
 		{
-			"defindex"			"327"
 			"price"				"600"
 			"kill_award"		"500"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Persian Persuader
+		"404"	// Persian Persuader
 		{
-			"defindex"			"404"
 			"price"				"600"
 			"kill_award"		"500"
 			"armor_penetration"	"0.85"
@@ -578,121 +506,109 @@
 		
 		// Heavy - Primary
 		 
-		"Weapon"	// Minigun
+		"15"	// Minigun
 		{
-			"defindex"			"15"
 			"price"				"4750"
 			"kill_award"		"100"
 			"armor_penetration"	"0.75"
+			"can_headshot"		"1"
 		}
-		"Weapon"	// Natascha
+		"41"	// Natascha
 		{
-			"defindex"			"41"
 			"price"				"4450"
 			"kill_award"		"100"
 			"armor_penetration"	"0.75"
+			"can_headshot"		"1"
 		}
-		"Weapon"	// Brass Beast
+		"312"	// Brass Beast
 		{
-			"defindex"			"312"
 			"price"				"4450"
 			"kill_award"		"100"
 			"armor_penetration"	"0.75"
+			"can_headshot"		"1"
 		}
-		"Weapon"	// Tomislav
+		"424"	// Tomislav
 		{
-			"defindex"			"424"
 			"price"				"4900"
 			"kill_award"		"100"
 			"armor_penetration"	"0.75"
+			"can_headshot"		"1"
 		}
-		"Weapon"	// Huo-Long Heater
+		"811"	// Huo-Long Heater
 		{
-			"defindex"			"811"
 			"price"				"4000"
 			"kill_award"		"100"
 			"armor_penetration"	"0.75"
+			"can_headshot"		"1"
 		}
 		
 		
 		// Heavy - Secondary
 		 
-		"Weapon"	// Heavy's Shotgun
+		"11"	// Heavy's Shotgun
 		{
-			"defindex"			"11"
 			"kill_award"		"300"
 			"armor_penetration" "0.75"
 			"is_default"		"1"
 		}
-		"Weapon"	// Sandvich
+		"42"	// Sandvich
 		{
-			"defindex"	"42"
 			"price"		"900"
 		}
-		"Weapon"	// Dalokohs Bar
+		"159"	// Dalokohs Bar
 		{
-			"defindex"	"159"
 			"price"		"500"
 		}
-		"Weapon"	// Buffalo Steak Sandvich
+		"311"	// Buffalo Steak Sandvich
 		{
-			"defindex"	"311"
 			"price"		"500"
 		}
-		"Weapon"	// Family Business 
+		"425"	// Family Business 
 		{
-			"defindex"			"425"
 			"price"				"700"
 			"kill_award"		"300"
 			"armor_penetration"	"0.8"
 		}
-		"Weapon"	// Second Banana
+		"1190"	// Second Banana
 		{
-			"defindex"	"1190"
 			"price"		"700"
 		}
 		
 		
 		// Heavy - Melee
 		 
-		"Weapon"	// Killing Gloves of Boxing 
+		"43"	// Killing Gloves of Boxing 
 		{
-			"defindex"			"43"
 			"price"				"600"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Gloves of Running Urgently 
+		"239"	// Gloves of Running Urgently 
 		{
-			"defindex"			"239"
 			"price"				"800"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Warrior's Spirit 
+		"310"	// Warrior's Spirit 
 		{
-			"defindex"			"310"
 			"price"				"600"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Fists of Steel 
+		"331"	// Fists of Steel 
 		{
-			"defindex"			"331"
 			"price"				"800"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Eviction Notice 
+		"426"	// Eviction Notice 
 		{
-			"defindex"			"426"
 			"price"				"500"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Holiday Punch
+		"656"	// Holiday Punch
 		{
-			"defindex"			"656"
 			"price"				"600"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
@@ -701,37 +617,32 @@
 		
 		// Engineer - Primary
 		 
-		"Weapon"		// Engineer's Shotgun
+		"9"		// Engineer's Shotgun
 		{
-			"defindex"			"9"
 			"kill_award"		"400"
 			"armor_penetration" "0.75"
 			"is_default"		"1"
 		}
-		"Weapon"	// Frontier Justice 
+		"141"	// Frontier Justice 
 		{
-			"defindex"			"141"
 			"price"				"950"
 			"kill_award"		"500"
 			"armor_penetration"	"0.75"
 		}
-		"Weapon"	// Widowmaker
+		"527"	// Widowmaker
 		{
-			"defindex"			"527"
 			"price"				"1250"
 			"kill_award"		"400"
 			"armor_penetration"	"0.75"
 		}
-		"Weapon"	// Pomson 6000
+		"588"	// Pomson 6000
 		{
-			"defindex"			"588"
 			"price"				"700"
 			"kill_award"		"600"
 			"armor_penetration"	"0.75"
 		}
-		"Weapon"	// Rescue Ranger
+		"997"	// Rescue Ranger
 		{
-			"defindex"			"997"
 			"price"				"1100"
 			"kill_award"		"600"
 			"armor_penetration"	"0.75"
@@ -740,56 +651,52 @@
 		
 		// Engineer - Secondary
 		 
-		"Weapon"	// Engineer's Pistol
+		"22"	// Engineer's Pistol
 		{
-			"defindex"			"22"
 			"kill_award"		"300"
 			"armor_penetration"	"0.475"
 			"is_default"		"1"
+			"can_headshot"		"1"
 		}
-		"Weapon"	// Wrangler
+		"140"	// Wrangler
 		{
-			"defindex"			"140"
 			"price"				"900"
 			"kill_award"		"400"
 			"armor_penetration"	"0.75"
+			"can_headshot"		"1"
 		}
-		"Weapon"	// Short Circuit
+		"528"	// Short Circuit
 		{
-			"defindex"			"528"
 			"price"				"500"
 			"kill_award"		"800"
 			"armor_penetration"	"0.475"
+			"can_headshot"		"1"
 		}
 		
 		
 		// Engineer - Melee
 		 
-		"Weapon"	// Gunslinger
+		"142"	// Gunslinger
 		{
-			"defindex"			"142"
 			"price"				"2450"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 			
 		}
-		"Weapon"	// Southern Hospitality
+		"155"	// Southern Hospitality
 		{
-			"defindex"			"155"
 			"price"				"650"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Jag
+		"329"	// Jag
 		{
-			"defindex"			"329"
 			"price"				"2300"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Eureka Effect 
+		"589"	// Eureka Effect 
 		{
-			"defindex"			"589"
 			"price"				"650"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
@@ -798,56 +705,49 @@
 		
 		// Engineer - PDA
 		 
-		"Weapon"	// Construction PDA
+		"25"	// Construction PDA
 		{
-			"defindex"	"25"
 			"price"		"2400"
 		}
 		
 		
 		// Engineer - PDA2
 		 
-		"Weapon"	// Destruction PDA
+		"26"	// Destruction PDA
 		{
-			"defindex"	"26"
 			"price"		"200"
 		}
 		
 		
 		// Engineer - Toolbox
 		 
-		"Weapon"	// PDA (ed: Toolbox) 
+		"28"	// PDA (ed: Toolbox) 
 		{
-			"defindex"		"28"
 			"is_default"	"1"
 		}
 		
 		
 		// Medic - Primary
 		 
-		"Weapon"	// Syringe Gun
+		"17"	// Syringe Gun
 		{
-			"defindex"		"17"
 			"kill_award"	"400"
 			"is_default"	"1"
 		}
-		"Weapon"	// Blutsauger
+		"36"	// Blutsauger
 		{
-			"defindex"			"36"
 			"price"				"700"
 			"kill_award"		"400"
 			"armor_penetration"	"0.5"
 		}
-		"Weapon"	// Crusader's Crossbow
+		"305"	// Crusader's Crossbow
 		{
-			"defindex"			"305"
 			"price"				"2150"
 			"kill_award"		"500"
 			"armor_penetration"	"0.775"
 		}
-		"Weapon"	// Overdose
+		"412"	// Overdose
 		{
-			"defindex"			"412"
 			"price"				"500"
 			"kill_award"		"400"
 			"armor_penetration"	"0.5"
@@ -856,27 +756,23 @@
 		
 		// Medic - Secondary
 		 
-		"Weapon"	// Medi Gun
+		"29"	// Medi Gun
 		{
-			"defindex"		"29"
 			"kill_award"	"400"
 			"price"			"4250"
 		}
-		"Weapon"	// Kritzkrieg
+		"35"	// Kritzkrieg
 		{
-			"defindex"		"35"
 			"kill_award"	"400"
 			"price"			"4100"
 		}
-		"Weapon"	// Quick-Fix
+		"411"	// Quick-Fix
 		{
-			"defindex"		"411"
 			"kill_award"	"400"
 			"price"			"4400"
 		}
-		"Weapon"	// Vaccinator
+		"998"	// Vaccinator
 		{
-			"defindex"		"998"
 			"kill_award"	"400"
 			"price"			"4100"
 		}
@@ -884,23 +780,20 @@
 		
 		// Medic - Melee
 		 
-		"Weapon"	// Ubersaw
+		"37"	// Ubersaw
 		{
-			"defindex"			"37"
 			"price"				"1100"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Amputator
+		"304"	// Amputator
 		{
-			"defindex"			"304"
 			"price"				"600"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Solemn Vow 
+		"413"	// Solemn Vow 
 		{
-			"defindex"			"413"
 			"price"				"500"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
@@ -909,51 +802,44 @@
 		
 		// Sniper - Primary
 		 
-		"Weapon"	// Huntsman
+		"56"	// Huntsman
 		{
-			"defindex"			"56"
 			"price"				"3300"
 			"kill_award"		"300"
 			"armor_penetration"	"0.9"
 		}
-		"Weapon"	// Sydney Sleeper
+		"230"	// Sydney Sleeper
 		{
-			"defindex"			"230"
 			"price"				"3450"
 			"kill_award"		"200"
 			"armor_penetration"	"0.975"
 		}
-		"Weapon"	// Bazaar Bargain 
+		"402"	// Bazaar Bargain 
 		{
-			"defindex"			"402"
 			"price"				"3150"
 			"kill_award"		"400"
 			"armor_penetration"	"0.975"
 		}
-		"Weapon"	// Machina
+		"526"	// Machina
 		{
-			"defindex"			"526"
 			"price"				"3750"
 			"kill_award"		"200"
 			"armor_penetration"	"0.975"
 		}
-		"Weapon"	// Hitman's Heatmaker
+		"752"	// Hitman's Heatmaker
 		{
-			"defindex"			"752"
 			"price"				"3150"
 			"kill_award"		"200"
 			"armor_penetration"	"0.975"
 		}
-		"Weapon"	// AWPer Hand
+		"851"	// AWPer Hand
 		{
-			"defindex"			"851"
 			"price"				"3750"
 			"kill_award"		"200"
 			"armor_penetration"	"0.975"
 		}
-		"Weapon"	// Classic
+		"1098"	// Classic
 		{
-			"defindex"			"1098"
 			"price"				"3300"
 			"kill_award"		"300"
 			"armor_penetration"	"0.975"
@@ -962,61 +848,54 @@
 		
 		// Sniper - Secondary
 		 
-		"Weapon"	// SMG
+		"16"	// SMG
 		{
-			"defindex"			"16"
 			"armor_penetration"	"0.6"
 			"kill_award"		"500"
 			"is_default"		"1"
+			"can_headshot"		"1"
 		}
-		"Weapon"	// Razorback
+		"57"	// Razorback
 		{
-			"defindex"	"57"
 			"price"		"500"
 		}
-		"Weapon"	// Jarate
+		"58"	// Jarate
 		{
-			"defindex"	"58"
 			"price"		"900"
 		}
-		"Weapon"	// Darwin's Danger Shield
+		"231"	// Darwin's Danger Shield
 		{
-			"defindex"	"231"
 			"price"		"700"
 		}
-		"Weapon"	// Cozy Camper 
+		"642"	// Cozy Camper 
 		{
-			"defindex"	"642"
 			"price"		"700"
 		}
-		"Weapon"	// Cleaner's Carbine
+		"751"	// Cleaner's Carbine
 		{
-			"defindex"			"751"
 			"price"				"700"
 			"kill_award"		"600"
 			"armor_penetration"	"0.6"
+			"can_headshot"		"1"
 		}
 		
 		
 		// Sniper - Melee
 		 
-		"Weapon"	// Tribalman's Shiv 
+		"171"	// Tribalman's Shiv 
 		{
-			"defindex"			"171"
 			"price"				"700"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Bushwacka
+		"232"	// Bushwacka
 		{
-			"defindex"			"232"
 			"price"				"500"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Shahanshah
+		"401"	// Shahanshah
 		{
-			"defindex"			"401"
 			"price"				"500"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
@@ -1025,90 +904,82 @@
 		
 		// Spy - Secondary
 		 
-		"Weapon"	// Revolver
+		"24"	// Revolver
 		{
-			"defindex"			"24"
+			"price"				"1750"
+			"kill_award"		"500"
+			"armor_penetration"	"0.925"
+			"can_headshot"		"1"
+		}
+		"61"	// Ambassador
+		{
 			"price"				"1750"
 			"kill_award"		"500"
 			"armor_penetration"	"0.925"
 		}
-		"Weapon"	// Ambassador
+		"224"	// L'Etranger
 		{
-			"defindex"			"61"
-			"price"				"1750"
-			"kill_award"		"500"
-			"armor_penetration"	"0.925"
-		}
-		"Weapon"	// L'Etranger
-		{
-			"defindex"			"224"
 			"price"				"1600"
 			"kill_award"		"500"
 			"armor_penetration"	"0.925"
+			"can_headshot"		"1"
 		}
-		"Weapon"	// Enforcer
+		"460"	// Enforcer
 		{
-			"defindex"			"460"
 			"price"				"1600"
 			"kill_award"		"500"
 			"armor_penetration"	"0.925"
+			"can_headshot"		"1"
 		}
-		"Weapon"	// Diamondback
+		"525"	// Diamondback
 		{
-			"defindex"			"525"
 			"price"				"1600"
 			"kill_award"		"500"
 			"armor_penetration"	"0.925"
+			"can_headshot"		"1"
 		}
 		
 		
 		// Spy - Building
 		 
-		"Weapon"	// Sapper
+		"735"	// Sapper
 		{
-			"defindex"		"735"
 			"is_default"	"1"
 		}
-		"Weapon"	// The Red-Tape Recorder
+		"810"	// The Red-Tape Recorder
 		{
-			"defindex"	"810"
 			"price"		"400"
 		}
 		
 		
 		// Spy - Melee
 		 
-		"Weapon"		// Knife
+		"4"		// Knife
 		{
-			"defindex"			"4"
 			"armor_penetration"	"1.0"
 			"kill_award"		"300"
 			"is_default"		"1"
 		}
-		"Weapon"	// Your Eternal Reward
+		"225"	// Your Eternal Reward
 		{
-			"defindex"			"225"
 			"price"				"600"
 			"kill_award"		"300"
 			"armor_penetration"	"1.0"
 		}
-		"Weapon"	// Conniver's Kunai
+		"356"	// Conniver's Kunai
 		{
-			"defindex"			"356"
 			"price"				"600"
 			"kill_award"		"300"
 			"armor_penetration"	"1.0"
 		}
-		"Weapon"	// The Big Earner 
+		"461"	// The Big Earner 
 		{
-			"defindex"			"461"
 			"price"				"600"
 			"kill_award"		"300"
 			"armor_penetration"	"1.0"
 		}
-		"Weapon"	// The Spy-cicle
+		"649"	// The Spy-cicle
 		{
-			"defindex"			"649"
 			"price"				"600"
 			"kill_award"		"300"
 			"armor_penetration"	"1.0"
@@ -1117,74 +988,64 @@
 		
 		// Spy - PDA
 		 
-		"Weapon"	// Disguise Kit
+		"27"	// Disguise Kit
 		{
-			"defindex"	"27"
 			"price"		"750"
 		}
 		
 		
 		// Spy - PDA2
 		 
-		"Weapon"	// Invis Watch
+		"30"	// Invis Watch
 		{
-			"defindex"		"30"
 			"is_default"	"1"
 		}
-		"Weapon"	// Dead Ringer
+		"59"	// Dead Ringer
 		{
-			"defindex"	"59"
 			"price"		"1750"
 		}
-		"Weapon"	// Cloak and Dagger
+		"60"	// Cloak and Dagger
 		{
-			"defindex"	"60"
 			"price"		"1150"
 		}
 		
 		
 		// Multiclass - Secondary
 		 
-		"Weapon"	// Reserve Shooter (Soldier, Pyro)
+		"415"	// Reserve Shooter (Soldier, Pyro)
 		{
-			"defindex"			"415"
 			"price"				"500"
 			"kill_award"		"500"
 			"armor_penetration"	"0.75"
 		}
-		"Weapon"	// Panic Attack (Soldier, Pyro, Engineer, Heavy)
+		"1153"	// Panic Attack (Soldier, Pyro, Engineer, Heavy)
 		{
-			"defindex"			"1153"
 			"price"				"700"
 			"kill_award"		"500"
 			"armor_penetration"	"0.75"
 		}
-		"Weapon"	// B.A.S.E. Jumper (Soldier/Demoman)
+		"1101"	// B.A.S.E. Jumper (Soldier/Demoman)
 		{
-			"defindex"	"1101"
 			"price"		"500"
 		}
 		
 		
 		// Multiclass - Melee
 		 
-		"Weapon"	// Pain Train (Soldier, Demoman)
+		"154"	// Pain Train (Soldier, Demoman)
 		{
-			"defindex"			"154"
 			"price"				"600"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Half-Zaotichi (Soldier, Demoman)
+		"357"	// Half-Zaotichi (Soldier, Demoman)
 		{
-			"defindex"			"357"
 			"price"				"700"
 			"kill_award"		"600"
 			"armor_penetration"	"0.85"
 		}
-		"Weapon"	// Prinny Machete
+		"30758"	// Prinny Machete
 		{
-			"defindex"			"30758"
 			"armor_penetration"	"0.85"
 			"kill_award"		"600"
 			"is_default"		"1"

--- a/addons/sourcemod/scripting/include/tfgo.inc
+++ b/addons/sourcemod/scripting/include/tfgo.inc
@@ -12,14 +12,18 @@ enum struct TFGOWeapon
 	int killAward;
 	float armorPenetration;
 	bool isDefault;
+	bool canHeadshot;
 	
 	void ReadConfig(KeyValues kv)
 	{
-		this.defindex = kv.GetNum("defindex", -1);
+		char defindex[8];
+		kv.GetSectionName(defindex, sizeof(defindex));
+		this.defindex = StringToInt(defindex);
 		this.price = kv.GetNum("price");
 		this.killAward = kv.GetNum("kill_award");
 		this.armorPenetration = kv.GetFloat("armor_penetration", 1.0);
 		this.isDefault = view_as<bool>(kv.GetNum("is_default"));
+		this.canHeadshot = view_as<bool>(kv.GetNum("can_headshot"));
 	}
 }
 

--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -178,7 +178,6 @@ TFTeam g_BombPlantingTeam;
 bool g_HasPlayerSuicided[TF_MAXPLAYERS + 1];
 
 // ConVars
-ConVar tfgo_use_hitlocation_dmg;
 ConVar tfgo_free_armor;
 ConVar tfgo_max_armor;
 ConVar tfgo_buytime;
@@ -272,7 +271,6 @@ public void OnPluginStart()
 	mp_friendlyfire = FindConVar("mp_friendlyfire");
 	
 	// Create TFGO ConVars
-	tfgo_use_hitlocation_dmg = CreateConVar("tfgo_use_hitlocation_dmg", "1", "Determines whether weapons deal hit location damage");
 	tfgo_free_armor = CreateConVar("tfgo_free_armor", "0", "Determines whether kevlar (1+) and/or helmet (2+) are given automatically", _, true, 0.0, true, 2.0);
 	tfgo_max_armor = CreateConVar("tfgo_max_armor", "2", "Determines the highest level of armor allowed to be purchased. (0) None, (1) Kevlar, (2) Helmet", _, true, 0.0, true, 2.0);
 	tfgo_buytime = CreateConVar("tfgo_buytime", "20", "How many seconds after spawning players can buy items for", _, true, tf_arena_preround_time.FloatValue);
@@ -481,32 +479,30 @@ Action SDKHook_Client_TraceAttack(int victim, int &attacker, int &inflictor, flo
 	
 	int activeWeapon = GetEntPropEnt(attacker, Prop_Send, "m_hActiveWeapon");
 	
-	if (tfgo_use_hitlocation_dmg.BoolValue)
+	// Headshots
+	if (IsValidEntity(activeWeapon))
 	{
-		// Headshots
+		int defindex = GetEntProp(activeWeapon, Prop_Send, "m_iItemDefinitionIndex");
 		TFGOWeapon config;
-		if (IsValidEntity(activeWeapon) && g_AvailableWeapons.GetByDefIndex(GetEntProp(activeWeapon, Prop_Send, "m_iItemDefinitionIndex"), config) > 0)
+		if (g_AvailableWeapons.GetByDefIndex(defindex, config) > 0 && config.canHeadshot)
 		{
-			if (config.canHeadshot)
-			{
-				damagetype |= DMG_USE_HITLOCATIONS;
-				action = Plugin_Changed;
-			}
+			damagetype |= DMG_USE_HITLOCATIONS;
+			action = Plugin_Changed;
 		}
-		
-		// Other hitgroup damage modifiers
-		switch (hitgroup)
+	}
+	
+	// Other hitgroup damage modifiers
+	switch (hitgroup)
+	{
+		case HITGROUP_STOMACH:
 		{
-			case HITGROUP_STOMACH:
-			{
-				damage *= 1.25;
-				action = Plugin_Changed;
-			}
-			case HITGROUP_LEFTLEG, HITGROUP_RIGHTLEG:
-			{
-				damage *= 0.75;
-				action = Plugin_Changed;
-			}
+			damage *= 1.25;
+			action = Plugin_Changed;
+		}
+		case HITGROUP_LEFTLEG, HITGROUP_RIGHTLEG:
+		{
+			damage *= 0.75;
+			action = Plugin_Changed;
 		}
 	}
 	
@@ -514,21 +510,19 @@ Action SDKHook_Client_TraceAttack(int victim, int &attacker, int &inflictor, flo
 	if (mp_friendlyfire.BoolValue || TF2_GetClientTeam(victim) != TF2_GetClientTeam(attacker) || victim == attacker)
 	{
 		TFGOPlayer player = TFGOPlayer(victim);
-		if (!(damagetype & (DMG_FALL | DMG_DROWN)) && player.IsArmored(hitgroup))
+		if (!(damagetype & (DMG_FALL | DMG_DROWN)) && player.IsArmored(hitgroup) && IsValidEntity(activeWeapon))
 		{
+			int defindex = GetEntProp(activeWeapon, Prop_Send, "m_iItemDefinitionIndex");
 			TFGOWeapon config;
-			if (IsValidEntity(activeWeapon) && g_AvailableWeapons.GetByDefIndex(GetEntProp(activeWeapon, Prop_Send, "m_iItemDefinitionIndex"), config) > 0)
+			if (g_AvailableWeapons.GetByDefIndex(defindex, config) > 0 && config.armorPenetration < 1.0) // Armor penetration >= 100% bypasses armor
 			{
-				if (config.armorPenetration < 1.0) // Armor penetration >= 100% bypasses armor
-				{
-					player.ArmorValue -= RoundFloat(damage);
-					damage *= config.armorPenetration;
-					action = Plugin_Changed;
-				}
+				player.ArmorValue -= RoundFloat(damage);
+				damage *= config.armorPenetration;
+				action = Plugin_Changed;
+				
+				if (player.ArmorValue <= 0)
+					player.HasHelmet = false;
 			}
-			
-			if (player.ArmorValue <= 0)
-				player.HasHelmet = false;
 		}
 	}
 	


### PR DESCRIPTION
Adds a new bool attribute ``can_headshot`` to the weapon config so individual weapons can be given headshot capabilities without having to rely on the damage type.