### PR TITLE
Fix ConVar values not reset properly after plugin unload

### DIFF
--- a/addons/sourcemod/scripting/tfgo/convar.sp
+++ b/addons/sourcemod/scripting/tfgo/convar.sp
@@ -51,8 +51,6 @@ void ConVar_Add(const char[] name, float value)
 	info.convar = FindConVar(name);
 	info.value = value;
 	ConVars.PushArray(info);
-	
-	info.convar.AddChangeHook(ConVar_OnChanged);
 }
 
 void ConVar_Enable()
@@ -65,6 +63,7 @@ void ConVar_Enable()
 		ConVars.SetArray(i, info);
 		
 		info.convar.SetFloat(info.value);
+		info.convar.AddChangeHook(ConVar_OnChanged);
 	}
 }
 
@@ -75,6 +74,7 @@ void ConVar_Disable()
 		ConVarInfo info;
 		ConVars.GetArray(i, info);
 		
+		info.convar.RemoveChangeHook(ConVar_OnChanged);
 		info.convar.SetFloat(info.defaultValue);
 	}
 }


### PR DESCRIPTION
When plugin unloads, `ConVar_Disable` is called to set value back to what it was, but `ConVar_OnChanged` reverts value back to tfgo value.
Hook convar change from `ConVar_Enable` and unhook from `ConVar_Disable`.