### PR TITLE
Delay Config_Init()

### DIFF
--- a/addons/sourcemod/scripting/tfgo.sp
+++ b/addons/sourcemod/scripting/tfgo.sp
@@ -300,7 +300,6 @@ public void OnPluginStart()
 	LoadTranslations("common.phrases.txt");
 	LoadTranslations("tfgo.phrases.txt");
 	
-	Config_Init();
 	Console_Init();
 	ConVar_Init();
 	Event_Init();
@@ -370,6 +369,11 @@ public void OnPluginEnd()
 	// Restore arena if needed
 	if (g_ArenaGameType)
 		GameRules_SetProp("m_nGameType", TF_GAMETYPE_ARENA);
+}
+
+public void OnAllPluginsLoaded()
+{
+	Config_Init();
 }
 
 public void OnMapStart()


### PR DESCRIPTION
Fixes a bug with TF Econ Data not having it's SDKCalls ready at the time.
```
[SM] Exception reported: Native is not bound
[SM] Blaming: tf_econ_data.smx
[SM] Call stack trace:
[SM]   [0] SDKCall
[SM]   [1] Line 423, tf_econ_data.sp::GetEconItemSchema
[SM]   [2] Line 366, tf_econ_data.sp::GetEconItemDefinition
[SM]   [3] Line 296, tf_econ_data/item_definition.sp::LoadEconItemDefinitionString
[SM]   [4] Line 33, tf_econ_data/item_definition.sp::Native_GetItemName
[SM]   [6] TF2Econ_GetItemName
[SM]   [7] Line 270, tfgo/stocks.sp::TF2_GetItemName
[SM]   [8] Line 64, tfgo/config.sp::SortFunc_SortAvailableWeaponsByName
[SM]   [10] ArrayList.SortCustom
[SM]   [11] Line 35, tfgo/config.sp::Config_Init
[SM]   [12] Line 303, tfgo.sp::OnPluginStart
[SM] Unable to load plugin "tfgo.smx": Error detected in plugin startup (see error logs)
```